### PR TITLE
Fix: don't lose icon when replacing followed threads link

### DIFF
--- a/src/globals-site.ts
+++ b/src/globals-site.ts
@@ -61,7 +61,6 @@ export const CLASS = {
     toolbarButton: "tbButton iconButton noselect",
     toolbarButtonIcon: "btnIcon",
     toolbarHeadingButton: "header",
-    hasUnread: "hasUnread",
 };
 
 export const PATH = {

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -239,7 +239,7 @@ const OPERATIONS: ReadonlyArray<Operation> = [
     new DependentOperation({
         description: "replace followed threads link with a link to my posts",
         condition: isLoggedIn() && Preferences.get(P.general._.replace_followed_threads_link),
-        selectors: { followedThreadsLink: SELECTOR.followedThreadsLink },
+        selectors: { followedThreadsLinkText: SELECTOR.followedThreadsLinkText },
         action: REPLACE_FOLLOWED_THREADS_LINK,
     }),
 

--- a/src/operations/replace-followed-threads-link.ts
+++ b/src/operations/replace-followed-threads-link.ts
@@ -1,9 +1,9 @@
 import * as SITE from "globals-site";
 import * as T from "text";
 
-export default (e: { followedThreadsLink: HTMLElement }) => {
-    const link = e.followedThreadsLink as HTMLAnchorElement;
-    link.textContent = T.general.my_posts;
+export default (e: { followedThreadsLinkText: HTMLElement }) => {
+    const text = e.followedThreadsLinkText;
+    const link = text.parentElement as HTMLAnchorElement;
+    text.textContent = T.general.my_posts;
     link.href = SITE.PATH.MY_POSTS;
-    (link.parentElement as HTMLElement).classList.remove(SITE.CLASS.hasUnread);
 }

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -40,6 +40,6 @@ export default {
     forumPostAuthorLink: `.name a`,
     listBulkActions: `#postActions .listBulkActions`,
     quickReplyForm: `#quickreply form`,
-    followedThreadsLink: `#${SITE.ID.siteHeader} .profile .option.watched a.label`,
+    followedThreadsLinkText: `#${SITE.ID.siteHeader} .profile .option.watched a.label>span:not(.icon)`,
     proofDialogCloseButton: "." + SITE.CLASS.proofDialog + " .cntClose",
 };

--- a/src/styles/replace-followed-threads-link.scss
+++ b/src/styles/replace-followed-threads-link.scss
@@ -5,7 +5,7 @@
 
     // Prevent orange link from flashing briefly before being replaced:
     &, & a.label {
-        color: unset;
+        color: unset !important; // to override Blargmode
         font-weight: unset;
     }
 }


### PR DESCRIPTION
SweClockers made a change on their side, which caused the current
implementation to remove the icon while replacing the text.