### PR TITLE
Add adaptive width style

### DIFF
--- a/src/preferences/general.ts
+++ b/src/preferences/general.ts
@@ -16,6 +16,11 @@ export default {
         default: false,
         label: T.preferences.general.compact_layout,
     }),
+    adaptive_width: new BooleanPreference({
+        key: "adaptive_width",
+        default: false,
+        label: T.preferences.general.adaptive_width,
+    }),
     improved_corrections: new BooleanPreference({
         key: "improved_corrections",
         default: true,

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -59,6 +59,10 @@ const STYLESHEET_MODULES: ReadonlyArray<StylesheetModule> = [
         css: require("styles/compact-layout"),
     },
     {
+        condition: Preferences.get(P.general._.adaptive_width),
+        css: require("styles/adaptive-width"),
+    },
+    {
         condition: Preferences.get(P.forum_threads._.improved_pagination_buttons),
         css: require("styles/improved-pagination-buttons"),
     },

--- a/src/styles/adaptive-width.scss
+++ b/src/styles/adaptive-width.scss
@@ -1,0 +1,109 @@
+/*
+    Move rightmost ad to make news pages and forum pages the same
+    width and let it go outside the visible area in narrow viewports.
+*/
+#content>.outsiderColumn {
+    >.fluid>.inner {
+        padding-right: 0;
+    }
+    >.fixed {
+        position: relative;
+        left: 250px;
+    }
+}
+
+/* Allow containers to shrink further */
+.container, .minWidth {
+    width: auto !important;
+    min-width: 940px;
+}
+
+/* Adjust search bar to fit in the thinner layout */
+#search {
+    min-width: 156px;
+    max-width: 180px;
+    width: 15vw;
+}
+
+/* Make footer fit */
+.footer .top .block {
+    width: 25%;
+    box-sizing: border-box;
+}
+
+/* Scale up images to fill width in article feed and articles */
+.newsList .itemBanner img,
+.articleHeader .bbImage img,
+.articleHeader .tv-frame,
+.articleContent .bbImage img,
+.gphi-banner img,
+.whiteHeader>.banner>img,
+.articleList .image img {
+    width: 100%;
+}
+
+/* Gallery images are special */
+.galleryImage {
+    margin-right: 10px;
+
+    >.image>img {
+        width: 100%;
+        box-sizing: border-box;
+    }
+}
+
+/* Frame for article video doesn't want to scale */
+.articleHeader .tv-frame {
+    .tvf-top,
+    .tvf-right,
+    .tvf-bottom,
+    .tvf-left {
+        display: none;
+    }
+}
+
+/* Sacrifice "Svara" on own posts to make room */
+.forumPost.isReader .button.reply {
+    display: none;
+}
+
+/* Clearfix box in articles that images tend to pop out of */
+.bbRelatedBox:after {
+    content: " ";
+    clear: both;
+    display: block;
+}
+
+/* Make empty space disappear if .pushColumn>.fixed has no content */
+.pushColumn {
+    display: flex;
+
+    >.fluid {
+        margin-right: 0;
+
+        >.inner {
+            padding-right: 0;
+
+            /* This part is just magic */
+            >* {
+                display: table;
+                table-layout: fixed;
+                width: 100%;
+                box-sizing: border-box;
+            }
+        }
+    }
+
+    >.fixed {
+        width: auto;
+
+        >.inner {
+            margin-left: 0;
+
+            >* {
+                margin-left: 8px;
+                width: 154px;
+            }
+        }
+    }
+}

--- a/src/text.ts
+++ b/src/text.ts
@@ -55,6 +55,7 @@ export const preferences = {
         label: `Allmänt`,
         lock_heights: `Lås höjden på reklam etc`,
         compact_layout: `Kompakt layout`,
+        adaptive_width: `LemonIllusions adaptiva layout`,
         improved_corrections: `Bättre rättelsegränssnitt`,
         insert_preferences_shortcut: `Genväg till inställningar för ${CONFIG.USERSCRIPT_NAME}`,
         replace_followed_threads_link: `Ersätt länken <em>Följda trådar</em> med <em>${my_posts}</em>`,


### PR DESCRIPTION
There was a [request](https://www.sweclockers.com/forum/post/18001453) to make articles as wide as the forum. I have had this functionality in my fork for a while, but because of a tricky condition that I didn't bother fixing, I never submitted a PR for it... until now! The condition is still not fixed, but maybe @SimonAlling has a good idea of how to either figure the entire condition out or make an acceptable workaround.

If anyone wants to try it out without building themselves, I've provided a testing build below. If you have any feedback you can comment here or @ me in the [official Better SweClockers thread](https://www.sweclockers.com/forum/trad/1541641-better-sweclockers-2018).


## [Install testing build beta.1](https://gist.github.com/LemonIllusion/598413618d1859532b63ece94c7ef4d6/raw/c6a09b31969fd08965ee8b49b22f84d4d559ef0a/better-sweclockers_v3.8.0_adaptive-width-beta.1.user.js)
Testing build built from a5f7f00fa757e5c805d3d72bd6e0a34d95f0f143