### PR TITLE
Update URL for Soitoras Dark Theme

### DIFF
--- a/src/dark-theme.ts
+++ b/src/dark-theme.ts
@@ -9,7 +9,7 @@ export const enum Source {
 export function darkThemeUrl(source: Source): string {
     switch (source) {
         case Source.BLARGMODE: return "https://blargmode.se/files/swec_dark_theme/style.css";
-        case Source.SOITORA: return "https://gitcdn.xyz/repo/Soitora/XHS-Styles/master/sweclockers-pure.css";
+        case Source.SOITORA: return "https://soitora.github.io/xhs-styles/sweclockers.css";
     }
     return assertUnreachable(source);
 }


### PR DESCRIPTION
Just updated the URL from GitCDN to GitHub Pages as per #25. 

I would like to exclude the theme from your backup server as it's the default option that isn't up-to-date (in fact: 7 months old version) – but I could not figure out how to only make your backup server only apply to Blargmodes Dark Theme.