### PR TITLE
Update URL for Soitora's dark theme

### DIFF
--- a/src/dark-theme.ts
+++ b/src/dark-theme.ts
@@ -9,7 +9,7 @@ export const enum Source {
 export function darkThemeUrl(source: Source): string {
     switch (source) {
         case Source.BLARGMODE: return "https://blargmode.se/files/swec_dark_theme/style.css";
-        case Source.SOITORA: return "https://soitora.github.io/xhs-styles/sweclockers.css";
+        case Source.SOITORA: return "https://soitora.com/xhs-styles/sweclockers.css";
     }
 }
 


### PR DESCRIPTION
Github Pages now use custom domain, reflect changes by switching source url to that new address.