### PR TITLE
Update/rewrite improved corrections

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,9 @@ export const EDITING_TOOLS_HEIGHT = "120px"; // to prevent jumping in preference
 // distance between article and left side of improved corrections dialog
 export const CORRECTIONS_DIALOG_OFFSET_PX = 20;
 
+// In adaptive width mode, the minimum width of the wrapper is the default narrow-layout wrapper width minus this amount:
+export const WRAPPER_WIDTH_EXTRA_ALLOWED_SHRINK_AMOUNT = 60;
+
 export const NBSP = "\u00A0";
 
 export const ID = {

--- a/src/site.ts
+++ b/src/site.ts
@@ -11,17 +11,15 @@ export const STYLESHEET_URL = "/css/combine.min.css";
 export const BANNER_HEIGHT_TOP = `${121}px`; // default height of top ad banner
 export const BANNER_HEIGHT_MID = `${360}px`; // default height of page ad modules
 export const WRAPPER_WIDTH_WIDE_PX = 1250;
-export const WRAPPER_WIDTH_NARROW_PX = 1002;
-export const MAX_WIDTH_FOR_NARROW_LAYOUT = `${1100}px`;
+export const WRAPPER_WIDTH_NARROW_PX = 1000;
+export const MAX_WIDTH_FOR_NARROW_LAYOUT_PX = 1100;
 export const EXTRA_TAB_MARGIN = `${8}px`;
-export const GUTTER_SIZE_PX = 8;
+export const GUTTER_SIZE_PX = 6; // the small padding to the very left and right
 export const OUTSIDER_COLUMN_FIXED_WIDTH_PX = 250;
 export const INSIDER_COLUMN_FIXED_WIDTH_PX = 314;
-export const PUSH_COLUMN_FIXED_WIDTH_PX = 162;
-export const ARTICLE_WIDTH_PX = 516; // (wide viewport; 518 in narrow)
-export const CORRECTIONS_DIALOG_WIDTH_PX = 384;
-export const FIXED_COLUMNS_TOTAL_WIDTH_NARROW_PX = INSIDER_COLUMN_FIXED_WIDTH_PX + PUSH_COLUMN_FIXED_WIDTH_PX;
-export const FIXED_COLUMNS_TOTAL_WIDTH_WIDE_PX = FIXED_COLUMNS_TOTAL_WIDTH_NARROW_PX + OUTSIDER_COLUMN_FIXED_WIDTH_PX;
+export const ARTICLE_WIDTH_PX = 680;
+export const WIDTH_WHERE_NARROW_LAYOUT_GOES_CENTERED = WRAPPER_WIDTH_NARROW_PX + 2 * GUTTER_SIZE_PX;
+export const WIDTH_WHERE_WIDE_LAYOUT_GOES_CENTERED = WRAPPER_WIDTH_WIDE_PX + 2 * GUTTER_SIZE_PX;
 
 export const ID = {
     siteHeader: "siteHeader",

--- a/src/stylesheets/adaptive-width-corrections.scss
+++ b/src/stylesheets/adaptive-width-corrections.scss
@@ -1,24 +1,52 @@
 ##{getGlobal("CONFIG.ID.document")} {
 
+// With adaptive width, there are not four distinct "modes", but three:
+//   * Minimum width, fixed to left viewport edge
+//   * Adaptive width, fixed to left viewport edge
+//   * Maximum width, centered
+
 $WRAPPER_WIDTH_WIDE_PX: getGlobal("SITE.WRAPPER_WIDTH_WIDE_PX");
+$WRAPPER_WIDTH_EXTRA_ALLOWED_SHRINK_AMOUNT: getGlobal("CONFIG.WRAPPER_WIDTH_EXTRA_ALLOWED_SHRINK_AMOUNT");
 $CORRECTIONS_DIALOG_OFFSET_PX: getGlobal("CONFIG.CORRECTIONS_DIALOG_OFFSET_PX");
-$FIXED_COLUMNS_TOTAL_WIDTH_NARROW_PX: getGlobal("SITE.FIXED_COLUMNS_TOTAL_WIDTH_NARROW_PX");
+$GUTTER_SIZE_PX: getGlobal("SITE.GUTTER_SIZE_PX");
+$ARTICLE_WIDTH_PX: getGlobal("SITE.ARTICLE_WIDTH_PX");
+$INSIDER_COLUMN_FIXED_WIDTH_PX: getGlobal("SITE.INSIDER_COLUMN_FIXED_WIDTH_PX");
+$WIDTH_WHERE_WIDE_LAYOUT_GOES_CENTERED: getGlobal("SITE.WIDTH_WHERE_WIDE_LAYOUT_GOES_CENTERED");
+$WIDTH_WHERE_NARROW_LAYOUT_STARTS_GROWING_ADAPTIVELY: #{
+    getGlobal("SITE.WIDTH_WHERE_NARROW_LAYOUT_GOES_CENTERED") - $WRAPPER_WIDTH_EXTRA_ALLOWED_SHRINK_AMOUNT
+};
 
 div.#{getGlobal("SITE.CLASS.proofDialog")} { /* explicit div to override default BSC */
-    .wndWindowArea {
-        left: calc(50% + #{
-            $CORRECTIONS_DIALOG_OFFSET_PX
-            + $WRAPPER_WIDTH_WIDE_PX/2
-            - $FIXED_COLUMNS_TOTAL_WIDTH_NARROW_PX
-        }px) !important;
-        right: unset;
+    @media screen and (max-width: #{$WIDTH_WHERE_NARROW_LAYOUT_STARTS_GROWING_ADAPTIVELY}px) {
+        // Minimum width, fixed to left viewport edge.
+        .wndWindowArea {
+            left: #{
+                $CORRECTIONS_DIALOG_OFFSET_PX
+                + $GUTTER_SIZE_PX
+                + $ARTICLE_WIDTH_PX
+                - $WRAPPER_WIDTH_EXTRA_ALLOWED_SHRINK_AMOUNT
+            }px !important;
+        }
     }
 
-    @media screen and (max-width: #{$WRAPPER_WIDTH_WIDE_PX}px) {
+    @media screen and (min-width: #{$WIDTH_WHERE_NARROW_LAYOUT_STARTS_GROWING_ADAPTIVELY}px) and (max-width: #{$WIDTH_WHERE_WIDE_LAYOUT_GOES_CENTERED}px) {
+        // Adaptive width, fixed to left viewport edge.
         .wndWindowArea {
-            left: calc(100% + #{
+            left: calc(100vw + #{
                 $CORRECTIONS_DIALOG_OFFSET_PX
-                - $FIXED_COLUMNS_TOTAL_WIDTH_NARROW_PX
+                - 2 * $GUTTER_SIZE_PX
+                - $INSIDER_COLUMN_FIXED_WIDTH_PX
+            }px) !important;
+        }
+    }
+
+    @media screen and (min-width: #{$WIDTH_WHERE_WIDE_LAYOUT_GOES_CENTERED}px) {
+        // Maximum width, centered.
+        .wndWindowArea {
+            left: calc(50% + #{
+                $CORRECTIONS_DIALOG_OFFSET_PX
+                + $WRAPPER_WIDTH_WIDE_PX/2
+                - $INSIDER_COLUMN_FIXED_WIDTH_PX
             }px) !important;
         }
     }

--- a/src/stylesheets/adaptive-width.scss
+++ b/src/stylesheets/adaptive-width.scss
@@ -15,7 +15,7 @@
 /* Allow containers to shrink further */
 .container, .minWidth, .outsiderColumn {
     width: auto !important;
-    min-width: 940px;
+    min-width: #{getGlobal("SITE.WRAPPER_WIDTH_NARROW_PX") - getGlobal("CONFIG.WRAPPER_WIDTH_EXTRA_ALLOWED_SHRINK_AMOUNT")}px;
 }
 
 /* Adjust search bar to fit in the thinner layout */

--- a/src/stylesheets/improved-corrections.scss
+++ b/src/stylesheets/improved-corrections.scss
@@ -1,16 +1,21 @@
 ##{getGlobal("CONFIG.ID.document")} {
 
+// SweClockers has one layout for narrow viewports and one for wide viewports; in the narrow one, the rightmost ad column is not shown.
+// In total, there are four "modes", from narrowest to widest:
+//   * Narrow layout, fixed to left viewport edge
+//   * Narrow layout, centered
+//   * Wide layout, fixed to left viewport edge
+//   * Wide layout, centered
+
 $ID_CORRECTIONS_LINK: getGlobal("SITE.ID.correctionsLink");
 $WRAPPER_WIDTH_WIDE_PX: getGlobal("SITE.WRAPPER_WIDTH_WIDE_PX");
 $WRAPPER_WIDTH_NARROW_PX: getGlobal("SITE.WRAPPER_WIDTH_NARROW_PX");
-$MAX_WIDTH_FOR_NARROW_LAYOUT: getGlobal("SITE.MAX_WIDTH_FOR_NARROW_LAYOUT");
+$MAX_WIDTH_FOR_NARROW_LAYOUT_PX: getGlobal("SITE.MAX_WIDTH_FOR_NARROW_LAYOUT_PX");
 $CORRECTIONS_DIALOG_OFFSET_PX: getGlobal("CONFIG.CORRECTIONS_DIALOG_OFFSET_PX");
 $GUTTER_SIZE_PX: getGlobal("SITE.GUTTER_SIZE_PX");
 $ARTICLE_WIDTH_PX: getGlobal("SITE.ARTICLE_WIDTH_PX");
-$FIXED_COLUMNS_TOTAL_WIDTH_NARROW_PX: getGlobal("SITE.FIXED_COLUMNS_TOTAL_WIDTH_NARROW_PX");
-$FIXED_COLUMNS_TOTAL_WIDTH_WIDE_PX: getGlobal("SITE.FIXED_COLUMNS_TOTAL_WIDTH_WIDE_PX");
-$CORRECTIONS_DIALOG_WIDTH_PX: getGlobal("SITE.CORRECTIONS_DIALOG_WIDTH_PX");
-$SCROLLBAR_APPROXIMATE_WIDTH_PX: 20;
+$WIDTH_WHERE_WIDE_LAYOUT_GOES_CENTERED: getGlobal("SITE.WIDTH_WHERE_WIDE_LAYOUT_GOES_CENTERED");
+$WIDTH_WHERE_NARROW_LAYOUT_GOES_CENTERED: getGlobal("SITE.WIDTH_WHERE_NARROW_LAYOUT_GOES_CENTERED");
 
 // Dialog
 .#{getGlobal("SITE.CLASS.proofDialog")} {
@@ -29,47 +34,39 @@ $SCROLLBAR_APPROXIMATE_WIDTH_PX: 20;
 
     .wndWindowArea {
         border: none;
-        left: calc(50% + #{
-            $CORRECTIONS_DIALOG_OFFSET_PX
-            + $WRAPPER_WIDTH_WIDE_PX/2
-            - $FIXED_COLUMNS_TOTAL_WIDTH_WIDE_PX
-        }px) !important;
         top: initial !important;
         opacity: 0.5;
         transition: opacity 200ms ease-in-out;
         pointer-events: initial;
+        // Effectively, because no @media query: Narrow or wide layout, fixed to left viewport edge.
+        left: #{
+            $CORRECTIONS_DIALOG_OFFSET_PX
+            + $GUTTER_SIZE_PX
+            + $ARTICLE_WIDTH_PX
+        }px !important;
     }
 
-    @media screen and (max-width: #{$WRAPPER_WIDTH_WIDE_PX}px) {
-        .wndWindowArea {
-            left: #{
-                $CORRECTIONS_DIALOG_OFFSET_PX
-                + $ARTICLE_WIDTH_PX
-                + $GUTTER_SIZE_PX
-            }px !important;
-        }
-    }
-
-    @media screen and (max-width: $MAX_WIDTH_FOR_NARROW_LAYOUT) and (min-width: #{$WRAPPER_WIDTH_NARROW_PX}px) {
+    @media screen and (min-width: #{$WIDTH_WHERE_NARROW_LAYOUT_GOES_CENTERED}px) and (max-width: #{$MAX_WIDTH_FOR_NARROW_LAYOUT_PX}px) {
+        // Narrow layout, centered.
         .wndWindowArea {
             left: calc(50% + #{
                 $CORRECTIONS_DIALOG_OFFSET_PX
-                + $WRAPPER_WIDTH_NARROW_PX/2
-                - $FIXED_COLUMNS_TOTAL_WIDTH_NARROW_PX
+                - $WRAPPER_WIDTH_NARROW_PX/2
+                + $GUTTER_SIZE_PX
+                + $ARTICLE_WIDTH_PX
             }px) !important;
         }
     }
 
-    @media screen and (max-width: #{
-            $CORRECTIONS_DIALOG_OFFSET_PX
-            + $ARTICLE_WIDTH_PX
-            + $CORRECTIONS_DIALOG_WIDTH_PX
-            + $SCROLLBAR_APPROXIMATE_WIDTH_PX
-            + 2*$GUTTER_SIZE_PX
-        }px) {
+    @media screen and (min-width: #{$WIDTH_WHERE_WIDE_LAYOUT_GOES_CENTERED}px) {
+        // Wide layout, centered.
         .wndWindowArea {
-            right: #{$GUTTER_SIZE_PX}px;
-            left: initial !important;
+            left: calc(50% + #{
+                $CORRECTIONS_DIALOG_OFFSET_PX
+                - $WRAPPER_WIDTH_WIDE_PX/2
+                + $GUTTER_SIZE_PX
+                + $ARTICLE_WIDTH_PX
+            }px) !important;
         }
     }
 


### PR DESCRIPTION
The feature had become broken by recent updates to the host site.

This is a difficult feature to implement and maintain overall. Not only
is it somewhat hard to know where the dialog _should_ be positioned;
browsers also behave differently. The implementation is also different
for LemonIllusion's adaptive layout.

The current implementation is practically perfect in Chrome and just
slightly off in Firefox when transitioning between layout "modes". I
think it's good enough.

Resolves #69.

Related: #70, #71.