### PR TITLE
Fix validation build running twice for PRs

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -1,6 +1,12 @@
 name: Validation
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   validation:


### PR DESCRIPTION
Two builds would be run for every push to a PR branch before.