### PR TITLE
Make quote button icons more intuitive

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -57,7 +57,7 @@ export const CLASS = {
     shibe: c("shibe"),
     button_restoreDraft: c("button-restore-draft"),
     button_color: c("button-color"),
-    button_quote: c("button-quote"),
+    button_blockquote: c("button-blockquote"),
     button_spoiler: c("button-spoiler"),
     button_code: c("button-code"),
     button_math: c("button-math"),
@@ -108,7 +108,7 @@ export const CONTENT = {
 
 export const ICONS = {
     // Requiring an SVG file here throws when building.
-    QUOTE: `<div>”</div>`,
+    BLOCKQUOTE: `<div>”</div>`,
     DOGE: `https://i.imgur.com/2IGEruO.png`,
 } as const;
 

--- a/src/icons/quote.svg
+++ b/src/icons/quote.svg
@@ -1,0 +1,10 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+    <rect x="1" y="1" width="30" height="30" stroke="#444" fill="#d7d5d1" stroke-width="2"/>
+    <text x="4" y="18" style="fill: #444; font-family: Georgia, serif; font-size: 20px">”</text>
+    <text       y="13" style="fill: #444; font-family: sans-serif; font-size: 4px">
+        <!-- Setting x="4" on text and x="0" on tspans doesn't work. -->
+        <tspan x="4" dy="1.2em">Dumheter</tspan>
+        <tspan x="4" dy="1.2em">som måste</tspan>
+        <tspan x="4" dy="1.2em">besvaras.</tspan>
+    </text>
+</svg>

--- a/src/operations/editing-tools.tsx
+++ b/src/operations/editing-tools.tsx
@@ -68,9 +68,9 @@ export function EditingTools(props: {
             {connectedTagButton({ tag: SITE.TAG.color, parameterized: true, tooltip: T.editing_tools.tooltip_color, class: CONFIG.CLASS.button_color })}
             {connectedTagButton({ tag: SITE.TAG.font, tooltip: T.editing_tools.tooltip_font, parameterized: true })}
             {connectedTagButton({ tag: SITE.TAG.mark, label: T.editing_tools.label_mark, tooltip: T.editing_tools.tooltip_mark })}
-            {connectedTagButton({ tag: SITE.TAG.quote, label: "", parameterized: true, tooltip: T.editing_tools.tooltip_quote, block: true, icon: { type: "RAW", image: CONFIG.ICONS.QUOTE }, class: CONFIG.CLASS.button_quote })}
+            {connected(BUTTON.quote)}
             {connected(BUTTON.splitQuote)}
-            {connectedTagButton({ tag: SITE.TAG.bq, label: T.editing_tools.label_bq, tooltip: T.editing_tools.tooltip_bq, block: true })}
+            {connectedTagButton({ tag: SITE.TAG.bq, label: "", tooltip: T.editing_tools.tooltip_bq, block: true, icon: { type: "RAW", image: CONFIG.ICONS.BLOCKQUOTE }, class: CONFIG.CLASS.button_blockquote })}
             {connected(BUTTON.expander)}
             {connectedTagButton({ tag: SITE.TAG.spoiler, tooltip: T.editing_tools.tooltip_spoiler, block: true, class: CONFIG.CLASS.button_spoiler })}
             {connectedInsertButton({ insert: CONFIG.CONTENT.edit, tooltip: T.editing_tools.tooltip_edit, label: T.editing_tools.label_edit })}

--- a/src/operations/logic/editing-tools.tsx
+++ b/src/operations/logic/editing-tools.tsx
@@ -5,6 +5,7 @@ import { h } from "preact";
 import * as CONFIG from "~src/config";
 import iconExpander from "~src/icons/expander.svg";
 import iconSearchLink from "~src/icons/search-link.svg";
+import iconQuote from "~src/icons/quote.svg";
 import iconSplitQuote from "~src/icons/split-quote.svg";
 import { SearchEngine, searchURL } from "~src/search-engines";
 import * as SITE from "~src/site";
@@ -46,6 +47,13 @@ export const BUTTON = {
         tooltip: T.editing_tools.tooltip_doge,
         action: insert(CONFIG.CONTENT.doge),
         icon: { type: "URL", image: CONFIG.ICONS.DOGE },
+    }),
+    quote: tagButton({
+        tag: SITE.TAG.quote,
+        parameterized: true,
+        block: true,
+        tooltip: T.editing_tools.tooltip_quote,
+        icon: { type: "RAW", image: iconQuote },
     }),
     splitQuote: generalButton({
         tooltip: T.editing_tools.tooltip_split_quote,

--- a/src/stylesheets/editing-tools.scss
+++ b/src/stylesheets/editing-tools.scss
@@ -86,8 +86,8 @@
         background: $FADE_INVERTED, $RAINBOW !important;
     }
 
-    // quote button icon:
-    .#{getGlobal("CONFIG.CLASS.button_quote")} div {
+    // blockquote button icon:
+    .#{getGlobal("CONFIG.CLASS.button_blockquote")} div {
         font-family: "Georgia", serif;
         font-size: 30px;
         line-height: 24px;


### PR DESCRIPTION
I for one always confused them because the old quote button icon (a big
quotation mark) didn't look like a forum quote at all, whereas the split
quote icon did (and still does). I think the big quotation mark icon is
better suited for the blockquote button.

**Before:**
![Quote buttons before](https://user-images.githubusercontent.com/7497533/87045373-182eec80-c1f8-11ea-9499-1a5d2d79dc74.png)

**After:**
![Quote buttons after](https://user-images.githubusercontent.com/7497533/87045746-883d7280-c1f8-11ea-8496-cf559c7bb785.png)

(Note that the button order hasn't changed.)
