### PR TITLE
Fix editing tools preview

### DIFF
--- a/src/preferences-menu.tsx
+++ b/src/preferences-menu.tsx
@@ -83,16 +83,11 @@ export class PreferencesForm extends Component {
         );
     }
 
-    public listener() {
-        this.forceUpdate();
-    }
-
     public componentDidMount() {
-        responseHandler.subscribe(this.listener);
-    }
-
-    public componentWillUnmount() {
-        responseHandler.unsubscribe(this.listener);
+        // The listener can't be a method, because then `this` is undefined in it.
+        responseHandler.subscribe(() => {
+            this.forceUpdate();
+        });
     }
 }
 


### PR DESCRIPTION
`this` would be undefined in `listener`, so the latter is now an inline
function instead. This means it can't be accessed in
`componentWillUnmount`, which is hence removed.

I'm content with this maybe-not-perfect hotfix because I want to rewrite
the entire preferences menu as a React application anyway; see #36.

Resolves #78.