### PR TITLE
Enable autosave draft for PMs

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -19,6 +19,7 @@ export const isInEditMode_PM = pathMatches(SITE.PATH.EDIT_MODE_PM);
 export const isInEditMode_report = pathMatches(SITE.PATH.EDIT_MODE_REPORT);
 export const isInEditMode_signature = pathMatches(SITE.PATH.EDIT_MODE_SIGNATURE);
 export const mayHaveJustSubmittedForumPost = pathMatches(SITE.PATH.SUCCESSFULLY_SUBMITTED_FORUM_POST);
+export const mayHaveJustSubmittedPM = pathMatches(SITE.PATH.SUCCESSFULLY_SUBMITTED_PM);
 
 export const isInEditMode = [
     isInEditMode_forum,

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -13,6 +13,7 @@ import {
     isReadingEditorialContent,
     isReadingThread,
     mayHaveJustSubmittedForumPost,
+    mayHaveJustSubmittedPM,
 } from "~src/environment";
 import { P, Preferences } from "~src/preferences";
 import SELECTOR from "~src/selectors";
@@ -254,7 +255,7 @@ const OPERATIONS: readonly Operation<any>[] = [
     }),
     operation({
         description: "enable autosave draft watchdog",
-        condition: () => isInEditMode_forum && Preferences.get(P.edit_mode._.autosave_draft),
+        condition: () => (isInEditMode_forum || isInEditMode_PM) && Preferences.get(P.edit_mode._.autosave_draft),
         dependencies: {
             saveButton: SELECTOR.saveButton,
             textarea: SELECTOR.textarea,
@@ -264,7 +265,7 @@ const OPERATIONS: readonly Operation<any>[] = [
     }),
     operation({
         description: "delete any obsolete autosaved draft",
-        condition: () => mayHaveJustSubmittedForumPost && Preferences.get(P.edit_mode._.autosave_draft),
+        condition: () => (mayHaveJustSubmittedForumPost || mayHaveJustSubmittedPM) && Preferences.get(P.edit_mode._.autosave_draft),
         dependencies: { post: SELECTOR.linkedForumPost },
         action: autosaveDraft.clearAutosavedDraftIfObsolete,
     }),

--- a/src/site.ts
+++ b/src/site.ts
@@ -114,6 +114,7 @@ export const PATH = {
     THREAD: /^\/(?:forum|medlem\/\d+\/meddelanden)\/trad\//,
     POST: /^\/(?:forum|medlem\/\d+\/meddelanden)\/post\//,
     SUCCESSFULLY_SUBMITTED_FORUM_POST: /^\/forum\/post\/\d+$/,
+    SUCCESSFULLY_SUBMITTED_PM: /^\/medlem\/\d+\/meddelanden\/(?:post\/\d+(?:#preview)?|trad\/\d+\-.+)$/,
     newPrivateMessage: (sender: number) => `/medlem/${sender}/meddelanden/nytt-meddelande`,
     forumPost: (postID: string) => `/forum/post/${postID}`,
     editPost: (postID: number) => `/forum/post/${postID}/redigera`,


### PR DESCRIPTION
No distinction is made between PMs and forum posts, so only one draft
(PM or forum post) can be saved at a time.