### PR TITLE
Fix layout issues in preferences menu

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@ const i = (x: string) => PREFIX_ID + x;
 const c = (x: string) => PREFIX_CLASS + x;
 
 export const ID_STYLE_ELEMENT = i("main-style-element");
-export const EDITING_TOOLS_HEIGHT = "120px"; // to prevent jumping in preferences interface
+export const EDITING_TOOLS_HEIGHT = "140px"; // to prevent jumping in preferences interface
 
 // distance between article and left side of improved corrections dialog
 export const CORRECTIONS_DIALOG_OFFSET_PX = 20;

--- a/src/stylesheets/editing-tools.scss
+++ b/src/stylesheets/editing-tools.scss
@@ -3,6 +3,7 @@
 // The actual toolbar:
 ##{getGlobal("CONFIG.ID.editingTools")} {
     margin: 1px; // same as textarea, so they line up
+    line-height: 0; // Prevents extraneous spacing below fieldsets.
     > * {
         vertical-align: top;
         margin-top: 0;
@@ -17,8 +18,6 @@
     $FADE: linear-gradient(to bottom, rgba(255,255,255,$FADE_OPACITY) 0%,rgba(0,0,0,$FADE_OPACITY) 100%);
     $FADE_BRIGHT: linear-gradient(to bottom, rgba(255,255,255,2*$FADE_OPACITY) 0%,rgba(100,100,100,2*$FADE_OPACITY) 100%);
     $FADE_INVERTED: linear-gradient(to top, rgba(255,255,255,$FADE_OPACITY) 0%,rgba(0,0,0,$FADE_OPACITY) 100%);
-
-    line-height: 0;
 
     big {
         font-size: 1.25em;


### PR DESCRIPTION
The editing tools checkboxes would be crammed together due to
`line-height: 0` and I had forgotten to update the height of the editing
tools.