### PR TITLE
Update Sweclockers Dark to use 3.X

### DIFF
--- a/src/dark-theme.ts
+++ b/src/dark-theme.ts
@@ -9,7 +9,7 @@ export const enum Source {
 export function darkThemeUrl(source: Source): string {
     switch (source) {
         case Source.BLARGMODE: return "https://blargmode.se/files/swec_dark_theme/style.css";
-        case Source.SOITORA: return "https://soitora.com/xhs-styles/sweclockers.css";
+        case Source.SOITORA: return "https://soitora.com/SweClockers-Dark/sweclockers-dark.min.css";
     }
 }
 


### PR DESCRIPTION
Kind of rewritten, much better and easier for me to support.

Also a question, is the "Use backup server" feature default or not? If it is, can you please make my theme bypass it as I consider GitHub to be stable enough to rely on completely.