### PR TITLE
Fix button line-height issue

### DIFF
--- a/src/stylesheets/editing-tools.scss
+++ b/src/stylesheets/editing-tools.scss
@@ -31,6 +31,9 @@
         height: 23px;
         box-sizing: border-box;
         margin: 0 1px 0 0;
+        * {
+            line-height: 0;
+        }
     }
 
     .#{getGlobal("SITE.CLASS.button")}:last-of-type {


### PR DESCRIPTION
Math button labels weren't properly aligned; neither were the buttons
themselves in the math tools preference description.

Regression introduced in #82.