### PR TITLE
Fix checkbox/radio button label placement

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -70,6 +70,7 @@ export const CLASS = {
     inlinePreference: c("inline-preference"),
     primaryInlinePreference: c("primary-inline-preference"),
     radioButtonPreference: c("radioButtonPreference"),
+    labeledInput: c("labeledInput"), // <label><input ... /></label>
     subforum: c("subforum"),
     textareaSize: c("textarea-size"),
     codeInput: c("code-input"),

--- a/src/preferences-menu.tsx
+++ b/src/preferences-menu.tsx
@@ -163,12 +163,12 @@ function InputElement<T extends AllowedTypes>(generators: Generators, p: Prefere
 }
 
 function Generator_Boolean(p: BooleanPreference): GeneratorOutput {
-    return [
+    return LabeledInput(
         <input type="checkbox" id={PID(p)} checked={Preferences.get(p)} onChange={e => {
             Preferences.set(p, (e.target as HTMLInputElement).checked);
         }} />,
-        <PreferenceLabel preference={p} />,
-    ];
+        p.label,
+    );
 }
 
 function Generator_String(p: StringPreference): GeneratorOutput {
@@ -295,9 +295,9 @@ function Generator_Multichoice<T extends AllowedTypes>(p: MultichoicePreference<
         );
 }
 
-function RadioButton<T extends AllowedTypes>({ p, label, value, checked }: { p: MultichoicePreference<T>, label: string, value: T, checked: boolean }): readonly JSX.Element[] {
+function RadioButton<T extends AllowedTypes>({ p, label, value, checked }: { p: MultichoicePreference<T>, label: string, value: T, checked: boolean }): JSX.Element {
     const radioButtonId = PID(p) + "-" + label;
-    return [
+    return LabeledInput(
         <input
             type="radio"
             id={radioButtonId}
@@ -309,8 +309,18 @@ function RadioButton<T extends AllowedTypes>({ p, label, value, checked }: { p: 
                 }
             }}
         />,
-        <HtmlLabel for={radioButtonId} html={label} />,
-    ];
+        label,
+    );
+}
+
+function LabeledInput(input: JSX.Element, label: string): JSX.Element {
+    return (
+        // Cannot use HtmlLabel because we want to have the <input> inside the <label> to avoid a line break between them.
+        <label class={ CONFIG.CLASS.labeledInput }>
+            { input }
+            <span dangerouslySetInnerHTML={{ __html: label }} />
+        </label>
+    );
 }
 
 function extractForumLinkData(forumLink: HTMLAnchorElement): ForumCategory | null {

--- a/src/stylesheets/preferences.scss
+++ b/src/stylesheets/preferences.scss
@@ -22,9 +22,15 @@ form##{getGlobal("CONFIG.USERSCRIPT_ID")} {
     #{$preference} {
         clear: left;
 
+        // Most labels should have a colon appended ...
         > label::after {
             content: ":\a0";
         }
+        // ... but not those that contain a checkbox or radio button.
+        > label.#{getGlobal("CONFIG.CLASS.labeledInput")}::after {
+            content: unset;
+        }
+        // The two rule sets above are separate because we don't want to default to appending a colon with high specificity.
 
         input + label::after, select + label::after, textarea + label::after {
             content: unset;
@@ -55,10 +61,6 @@ form##{getGlobal("CONFIG.USERSCRIPT_ID")} {
         width: -webkit-fit-content;
         width: -moz-fit-content;
         width: fit-content;
-
-        label::after {
-            content: unset;
-        }
 
         > label:first-child::after {
             content: ":";
@@ -124,12 +126,9 @@ form##{getGlobal("CONFIG.USERSCRIPT_ID")} {
         }
     }
 
-    input[type="checkbox"] + label, input[type="radio"] + label {
-        padding-left: $checkboxLabelSpacing;
-    }
-
     input[type="checkbox"], input[type="radio"] {
         margin: 0;
+        margin-right: $checkboxLabelSpacing;
     }
 
     input[type="text"], input[type="number"], input[type="time"] {


### PR DESCRIPTION
In the preferences menu, when multiple checkboxes or radio buttons
didn't fit on one line, the line could wrap between the input and the
label, which is very ugly and incredibly bad UX.

The proofread_articles preference was already affected in Firefox today,
and I will soon introduce a new preference that would have been affected
as well.