### PR TITLE
Add undo support for our editing tools

### DIFF
--- a/__tests__/browser.test.ts
+++ b/__tests__/browser.test.ts
@@ -17,8 +17,7 @@ describe("Android detection", () => {
             `Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1`, // iPad Pro, iOS 11, Safari (from Chrome developer tools)
             `Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1`, // iPhone X, iOS 13, Safari (from Chrome developer tools)
         ] as const;
-        // Enforce sorted order in source code:
-        expect(NON_ANDROID_USER_AGENT_STRINGS).toEqual(sorted(NON_ANDROID_USER_AGENT_STRINGS));
+        expect(NON_ANDROID_USER_AGENT_STRINGS).toEqual(sorted(NON_ANDROID_USER_AGENT_STRINGS)); // Enforces sorted order above.
         const soundnessSpecification = NON_ANDROID_USER_AGENT_STRINGS.map(x => ({ in: x, out: false }));
         check(browser.isAndroid).against(soundnessSpecification);
     });
@@ -33,8 +32,7 @@ describe("Android detection", () => {
             `Mozilla/5.0 (Linux; Android 7.0; F5321) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36`, // Xperia X Compact, Chrome
             `Mozilla/5.0 (Linux; Android 7.1.2; AFTMM Build/NS6265; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36`, // WIMB
         ] as const;
-        // Enforce sorted order in source code:
-        expect(ANDROID_USER_AGENT_STRINGS).toEqual(sorted(ANDROID_USER_AGENT_STRINGS));
+        expect(ANDROID_USER_AGENT_STRINGS).toEqual(sorted(ANDROID_USER_AGENT_STRINGS)); // Enforces sorted order above.
         const completenessSpecification = ANDROID_USER_AGENT_STRINGS.map(x => ({ in: x, out: true }));
         check(browser.isAndroid).against(completenessSpecification);
     });

--- a/__tests__/browser.test.ts
+++ b/__tests__/browser.test.ts
@@ -1,0 +1,41 @@
+import { check } from "jest-function";
+
+import * as browser from "../src/browser";
+
+import { sorted } from "./utilities";
+
+// What Is My Browser (WIMB) Database:
+// https://developers.whatismybrowser.com/useragents/explore/software_type_specific/web-browser
+
+describe("Android detection", () => {
+    it("is sound", () => {
+        const NON_ANDROID_USER_AGENT_STRINGS = [
+            `Mozilla/5.0 (Windows NT 5.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36`, // Windows, Chrome 60 (from WIMB)
+            `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36`, // Ubuntu 20.04, Chrome 83
+            `Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:24.0) Gecko/20100101 Firefox/24.0`, // Ubuntu, Firefox 24 (from WIMB)
+            `Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0`, // Ubuntu 20.04, Firefox 78
+            `Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1`, // iPad Pro, iOS 11, Safari (from Chrome developer tools)
+            `Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1`, // iPhone X, iOS 13, Safari (from Chrome developer tools)
+        ] as const;
+        // Enforce sorted order in source code:
+        expect(NON_ANDROID_USER_AGENT_STRINGS).toEqual(sorted(NON_ANDROID_USER_AGENT_STRINGS));
+        const soundnessSpecification = NON_ANDROID_USER_AGENT_STRINGS.map(x => ({ in: x, out: false }));
+        check(browser.isAndroid).against(soundnessSpecification);
+    });
+
+    it("is complete", () => {
+        const ANDROID_USER_AGENT_STRINGS = [
+            `Mozilla/5.0 (Android 10; Mobile; rv:68.0) Gecko/68.0 Firefox/68.0`, // Galaxy S9, Firefox
+            `Mozilla/5.0 (Linux; Android 10; SM-G960F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36`, // Galaxy S9, Chrome
+            `Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Mobile Safari/537.36`, // Galaxy S5 in Chrome developer tools
+            `Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Mobile Safari/537.36`, // Moto G4 in Chrome developer tools
+            `Mozilla/5.0 (Linux; Android 6.0.1; RedMi Note 5 Build/RB3N5C; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36`, // WIMB
+            `Mozilla/5.0 (Linux; Android 7.0; F5321) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36`, // Xperia X Compact, Chrome
+            `Mozilla/5.0 (Linux; Android 7.1.2; AFTMM Build/NS6265; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36`, // WIMB
+        ] as const;
+        // Enforce sorted order in source code:
+        expect(ANDROID_USER_AGENT_STRINGS).toEqual(sorted(ANDROID_USER_AGENT_STRINGS));
+        const completenessSpecification = ANDROID_USER_AGENT_STRINGS.map(x => ({ in: x, out: true }));
+        check(browser.isAndroid).against(completenessSpecification);
+    });
+});

--- a/__tests__/utilities.ts
+++ b/__tests__/utilities.ts
@@ -1,0 +1,4 @@
+// Pure (not in-place) sort function.
+export function sorted<T>(xs: readonly T[]): T[] {
+    return xs.slice().sort();
+}

--- a/docs/dialogs.md
+++ b/docs/dialogs.md
@@ -1,0 +1,20 @@
+In Chrome, at least version 83 on Ubuntu 20.04, pressing Esc (instead of clicking Cancel) when a `confirm`/`alert`/`prompt` dialog is being shown causes all text input elements, including the textarea, to become disabled/grayed out until the page/viewport/document is unfocused (e.g. by focusing the address bar, Alt-tabbing or triggering another dialog).
+Not even reloading the page enables them again (although it may seem like it if `prevent_accidental_unload` is enabled, since its popup takes focus from the page).
+
+## Minimal example
+
+```html
+<!DOCTYPE html>
+
+<title>Dialogs</title>
+
+<textarea></textarea>
+
+<a href="javascript:void(0)" onclick="alert('A');">Click here</a>
+```
+
+The problem seems to lie with the dialogs themselves and not how they are triggered:
+
+* `<a>` or `<input type="button">` doesn't matter.
+* `onclick` or `addEventListener` doesn't matter.
+* `javascript:void(0)` or `#` doesn't matter.

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
         "tsx",
         "js",
     ],
+    "testMatch": [ "**/?(*.)+(spec|test).[jt]s?(x)" ],
     "transform": {
         "^.+\\.tsx?$": "ts-jest",
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5689,6 +5689,11 @@
         }
       }
     },
+    "text-field-edit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/text-field-edit/-/text-field-edit-3.1.0.tgz",
+      "integrity": "sha512-4mVLiSRR5/p0Zhdl8QkjkUeYUDMSQSYdKsEgR6uOySjcc6QB/O2hzuUlxepL2kQQL0NrpYiI6Ywj6TZULYI9/w=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2079,6 +2079,11 @@
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -2180,6 +2185,11 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
       "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
+    },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -2506,6 +2516,21 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
+    },
+    "browser-resolve": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+      "requires": {
+        "resolve": "1.1.7"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+        }
+      }
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -4579,8 +4604,7 @@
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "optional": true
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -4941,6 +4965,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -6137,6 +6169,1278 @@
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jest-function/-/jest-function-1.0.1.tgz",
+      "integrity": "sha512-bXtg8kIs9oCA+lAX5DSMYHLsR1CgZScJqX7XWHtQZ+yBRRaROTCwM3i8/J91uMCj6BydzVlTL1Geoo7xlfNnhg==",
+      "requires": {
+        "@types/jest": "^24.0.15",
+        "jest": "^24.8.0"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
+          "integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
+          "requires": {
+            "@jest/source-map": "^24.9.0",
+            "chalk": "^2.0.1",
+            "slash": "^2.0.0"
+          }
+        },
+        "@jest/core": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
+          "integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
+          "requires": {
+            "@jest/console": "^24.7.1",
+            "@jest/reporters": "^24.9.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/transform": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.1.15",
+            "jest-changed-files": "^24.9.0",
+            "jest-config": "^24.9.0",
+            "jest-haste-map": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-regex-util": "^24.3.0",
+            "jest-resolve": "^24.9.0",
+            "jest-resolve-dependencies": "^24.9.0",
+            "jest-runner": "^24.9.0",
+            "jest-runtime": "^24.9.0",
+            "jest-snapshot": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jest-validate": "^24.9.0",
+            "jest-watcher": "^24.9.0",
+            "micromatch": "^3.1.10",
+            "p-each-series": "^1.0.0",
+            "realpath-native": "^1.1.0",
+            "rimraf": "^2.5.4",
+            "slash": "^2.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "@jest/environment": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
+          "integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
+          "requires": {
+            "@jest/fake-timers": "^24.9.0",
+            "@jest/transform": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "jest-mock": "^24.9.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
+          "integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-mock": "^24.9.0"
+          }
+        },
+        "@jest/reporters": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
+          "integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
+          "requires": {
+            "@jest/environment": "^24.9.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/transform": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "glob": "^7.1.2",
+            "istanbul-lib-coverage": "^2.0.2",
+            "istanbul-lib-instrument": "^3.0.1",
+            "istanbul-lib-report": "^2.0.4",
+            "istanbul-lib-source-maps": "^3.0.1",
+            "istanbul-reports": "^2.2.6",
+            "jest-haste-map": "^24.9.0",
+            "jest-resolve": "^24.9.0",
+            "jest-runtime": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jest-worker": "^24.6.0",
+            "node-notifier": "^5.4.2",
+            "slash": "^2.0.0",
+            "source-map": "^0.6.0",
+            "string-length": "^2.0.0"
+          }
+        },
+        "@jest/source-map": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
+          "integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
+          "requires": {
+            "callsites": "^3.0.0",
+            "graceful-fs": "^4.1.15",
+            "source-map": "^0.6.0"
+          }
+        },
+        "@jest/test-result": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
+          "integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
+          "requires": {
+            "@jest/console": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "@types/istanbul-lib-coverage": "^2.0.0"
+          }
+        },
+        "@jest/test-sequencer": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
+          "integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
+          "requires": {
+            "@jest/test-result": "^24.9.0",
+            "jest-haste-map": "^24.9.0",
+            "jest-runner": "^24.9.0",
+            "jest-runtime": "^24.9.0"
+          }
+        },
+        "@jest/transform": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
+          "integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/types": "^24.9.0",
+            "babel-plugin-istanbul": "^5.1.0",
+            "chalk": "^2.0.1",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graceful-fs": "^4.1.15",
+            "jest-haste-map": "^24.9.0",
+            "jest-regex-util": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "micromatch": "^3.1.10",
+            "pirates": "^4.0.1",
+            "realpath-native": "^1.1.0",
+            "slash": "^2.0.0",
+            "source-map": "^0.6.1",
+            "write-file-atomic": "2.4.1"
+          }
+        },
+        "@jest/types": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+          "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^13.0.0"
+          }
+        },
+        "@types/jest": {
+          "version": "24.9.1",
+          "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz",
+          "integrity": "sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==",
+          "requires": {
+            "jest-diff": "^24.3.0"
+          }
+        },
+        "acorn": {
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+        },
+        "acorn-globals": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+          "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+          "requires": {
+            "acorn": "^6.0.1",
+            "acorn-walk": "^6.0.1"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "6.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+              "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+            }
+          }
+        },
+        "acorn-walk": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+          "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          }
+        },
+        "babel-jest": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
+          "integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
+          "requires": {
+            "@jest/transform": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "@types/babel__core": "^7.1.0",
+            "babel-plugin-istanbul": "^5.1.0",
+            "babel-preset-jest": "^24.9.0",
+            "chalk": "^2.4.2",
+            "slash": "^2.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "babel-plugin-istanbul": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+          "integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "find-up": "^3.0.0",
+            "istanbul-lib-instrument": "^3.3.0",
+            "test-exclude": "^5.2.3"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
+          "integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
+          "requires": {
+            "@types/babel__traverse": "^7.0.6"
+          }
+        },
+        "babel-preset-jest": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
+          "integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
+          "requires": {
+            "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+            "babel-plugin-jest-hoist": "^24.9.0"
+          }
+        },
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+        },
+        "cssstyle": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+          "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+          "requires": {
+            "cssom": "0.3.x"
+          }
+        },
+        "data-urls": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+          "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+          "requires": {
+            "abab": "^2.0.0",
+            "whatwg-mimetype": "^2.2.0",
+            "whatwg-url": "^7.0.0"
+          },
+          "dependencies": {
+            "whatwg-url": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+              "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+              "requires": {
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^1.0.1",
+                "webidl-conversions": "^4.0.2"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "detect-newline": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+          "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+        },
+        "diff-sequences": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+          "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew=="
+        },
+        "domexception": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+          "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+          "requires": {
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+        },
+        "expect": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
+          "integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "ansi-styles": "^3.2.0",
+            "jest-get-type": "^24.9.0",
+            "jest-matcher-utils": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-regex-util": "^24.9.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+        },
+        "html-encoding-sniffer": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+          "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+          "requires": {
+            "whatwg-encoding": "^1.0.1"
+          }
+        },
+        "import-local": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+          "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+          "requires": {
+            "pkg-dir": "^3.0.0",
+            "resolve-cwd": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "istanbul-lib-coverage": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+          "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA=="
+        },
+        "istanbul-lib-instrument": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+          "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+          "requires": {
+            "@babel/generator": "^7.4.0",
+            "@babel/parser": "^7.4.3",
+            "@babel/template": "^7.4.0",
+            "@babel/traverse": "^7.4.3",
+            "@babel/types": "^7.4.0",
+            "istanbul-lib-coverage": "^2.0.5",
+            "semver": "^6.0.0"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+          "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+          "requires": {
+            "istanbul-lib-coverage": "^2.0.5",
+            "make-dir": "^2.1.0",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+          "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+          "requires": {
+            "debug": "^4.1.1",
+            "istanbul-lib-coverage": "^2.0.5",
+            "make-dir": "^2.1.0",
+            "rimraf": "^2.6.3",
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.1.6",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+              "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
+          }
+        },
+        "istanbul-reports": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+          "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
+          "requires": {
+            "html-escaper": "^2.0.0"
+          }
+        },
+        "jest": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
+          "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
+          "requires": {
+            "import-local": "^2.0.0",
+            "jest-cli": "^24.9.0"
+          },
+          "dependencies": {
+            "jest-cli": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
+              "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
+              "requires": {
+                "@jest/core": "^24.9.0",
+                "@jest/test-result": "^24.9.0",
+                "@jest/types": "^24.9.0",
+                "chalk": "^2.0.1",
+                "exit": "^0.1.2",
+                "import-local": "^2.0.0",
+                "is-ci": "^2.0.0",
+                "jest-config": "^24.9.0",
+                "jest-util": "^24.9.0",
+                "jest-validate": "^24.9.0",
+                "prompts": "^2.0.1",
+                "realpath-native": "^1.1.0",
+                "yargs": "^13.3.0"
+              }
+            }
+          }
+        },
+        "jest-changed-files": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
+          "integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "execa": "^1.0.0",
+            "throat": "^4.0.0"
+          }
+        },
+        "jest-config": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
+          "integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/test-sequencer": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "babel-jest": "^24.9.0",
+            "chalk": "^2.0.1",
+            "glob": "^7.1.1",
+            "jest-environment-jsdom": "^24.9.0",
+            "jest-environment-node": "^24.9.0",
+            "jest-get-type": "^24.9.0",
+            "jest-jasmine2": "^24.9.0",
+            "jest-regex-util": "^24.3.0",
+            "jest-resolve": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jest-validate": "^24.9.0",
+            "micromatch": "^3.1.10",
+            "pretty-format": "^24.9.0",
+            "realpath-native": "^1.1.0"
+          }
+        },
+        "jest-diff": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+          "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+          "requires": {
+            "chalk": "^2.0.1",
+            "diff-sequences": "^24.9.0",
+            "jest-get-type": "^24.9.0",
+            "pretty-format": "^24.9.0"
+          }
+        },
+        "jest-docblock": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
+          "integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
+          "requires": {
+            "detect-newline": "^2.1.0"
+          }
+        },
+        "jest-each": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
+          "integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "chalk": "^2.0.1",
+            "jest-get-type": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "pretty-format": "^24.9.0"
+          }
+        },
+        "jest-environment-jsdom": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
+          "integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
+          "requires": {
+            "@jest/environment": "^24.9.0",
+            "@jest/fake-timers": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "jest-mock": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jsdom": "^11.5.1"
+          }
+        },
+        "jest-environment-node": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
+          "integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
+          "requires": {
+            "@jest/environment": "^24.9.0",
+            "@jest/fake-timers": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "jest-mock": "^24.9.0",
+            "jest-util": "^24.9.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+          "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q=="
+        },
+        "jest-haste-map": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
+          "integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "anymatch": "^2.0.0",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^1.2.7",
+            "graceful-fs": "^4.1.15",
+            "invariant": "^2.2.4",
+            "jest-serializer": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jest-worker": "^24.9.0",
+            "micromatch": "^3.1.10",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-jasmine2": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
+          "integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
+          "requires": {
+            "@babel/traverse": "^7.1.0",
+            "@jest/environment": "^24.9.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "chalk": "^2.0.1",
+            "co": "^4.6.0",
+            "expect": "^24.9.0",
+            "is-generator-fn": "^2.0.0",
+            "jest-each": "^24.9.0",
+            "jest-matcher-utils": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-runtime": "^24.9.0",
+            "jest-snapshot": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "pretty-format": "^24.9.0",
+            "throat": "^4.0.0"
+          }
+        },
+        "jest-leak-detector": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
+          "integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
+          "requires": {
+            "jest-get-type": "^24.9.0",
+            "pretty-format": "^24.9.0"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+          "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-diff": "^24.9.0",
+            "jest-get-type": "^24.9.0",
+            "pretty-format": "^24.9.0"
+          }
+        },
+        "jest-message-util": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
+          "integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "@types/stack-utils": "^1.0.1",
+            "chalk": "^2.0.1",
+            "micromatch": "^3.1.10",
+            "slash": "^2.0.0",
+            "stack-utils": "^1.0.1"
+          }
+        },
+        "jest-mock": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
+          "integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
+          "requires": {
+            "@jest/types": "^24.9.0"
+          }
+        },
+        "jest-regex-util": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+          "integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA=="
+        },
+        "jest-resolve": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
+          "integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "browser-resolve": "^1.11.3",
+            "chalk": "^2.0.1",
+            "jest-pnp-resolver": "^1.2.1",
+            "realpath-native": "^1.1.0"
+          }
+        },
+        "jest-resolve-dependencies": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
+          "integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "jest-regex-util": "^24.3.0",
+            "jest-snapshot": "^24.9.0"
+          }
+        },
+        "jest-runner": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
+          "integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
+          "requires": {
+            "@jest/console": "^24.7.1",
+            "@jest/environment": "^24.9.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "chalk": "^2.4.2",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.1.15",
+            "jest-config": "^24.9.0",
+            "jest-docblock": "^24.3.0",
+            "jest-haste-map": "^24.9.0",
+            "jest-jasmine2": "^24.9.0",
+            "jest-leak-detector": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-resolve": "^24.9.0",
+            "jest-runtime": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jest-worker": "^24.6.0",
+            "source-map-support": "^0.5.6",
+            "throat": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "jest-runtime": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
+          "integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
+          "requires": {
+            "@jest/console": "^24.7.1",
+            "@jest/environment": "^24.9.0",
+            "@jest/source-map": "^24.3.0",
+            "@jest/transform": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "@types/yargs": "^13.0.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.1.15",
+            "jest-config": "^24.9.0",
+            "jest-haste-map": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-mock": "^24.9.0",
+            "jest-regex-util": "^24.3.0",
+            "jest-resolve": "^24.9.0",
+            "jest-snapshot": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jest-validate": "^24.9.0",
+            "realpath-native": "^1.1.0",
+            "slash": "^2.0.0",
+            "strip-bom": "^3.0.0",
+            "yargs": "^13.3.0"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.1.6",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+              "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
+          }
+        },
+        "jest-serializer": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
+          "integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ=="
+        },
+        "jest-snapshot": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
+          "integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
+          "requires": {
+            "@babel/types": "^7.0.0",
+            "@jest/types": "^24.9.0",
+            "chalk": "^2.0.1",
+            "expect": "^24.9.0",
+            "jest-diff": "^24.9.0",
+            "jest-get-type": "^24.9.0",
+            "jest-matcher-utils": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-resolve": "^24.9.0",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^24.9.0",
+            "semver": "^6.2.0"
+          }
+        },
+        "jest-util": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
+          "integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
+          "requires": {
+            "@jest/console": "^24.9.0",
+            "@jest/fake-timers": "^24.9.0",
+            "@jest/source-map": "^24.9.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "callsites": "^3.0.0",
+            "chalk": "^2.0.1",
+            "graceful-fs": "^4.1.15",
+            "is-ci": "^2.0.0",
+            "mkdirp": "^0.5.1",
+            "slash": "^2.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "jest-validate": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
+          "integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "camelcase": "^5.3.1",
+            "chalk": "^2.0.1",
+            "jest-get-type": "^24.9.0",
+            "leven": "^3.1.0",
+            "pretty-format": "^24.9.0"
+          }
+        },
+        "jest-watcher": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.9.0.tgz",
+          "integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
+          "requires": {
+            "@jest/test-result": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "@types/yargs": "^13.0.0",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.1",
+            "jest-util": "^24.9.0",
+            "string-length": "^2.0.0"
+          }
+        },
+        "jest-worker": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
+          "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+          "requires": {
+            "merge-stream": "^2.0.0",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "jsdom": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+          "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+          "requires": {
+            "abab": "^2.0.0",
+            "acorn": "^5.5.3",
+            "acorn-globals": "^4.1.0",
+            "array-equal": "^1.0.0",
+            "cssom": ">= 0.3.2 < 0.4.0",
+            "cssstyle": "^1.0.0",
+            "data-urls": "^1.0.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.9.1",
+            "html-encoding-sniffer": "^1.0.2",
+            "left-pad": "^1.3.0",
+            "nwsapi": "^2.0.7",
+            "parse5": "4.0.0",
+            "pn": "^1.1.0",
+            "request": "^2.87.0",
+            "request-promise-native": "^1.0.5",
+            "sax": "^1.2.4",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^2.3.4",
+            "w3c-hr-time": "^1.0.1",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.3",
+            "whatwg-mimetype": "^2.1.0",
+            "whatwg-url": "^6.4.1",
+            "ws": "^5.2.0",
+            "xml-name-validator": "^3.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node-notifier": {
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
+          "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+          "requires": {
+            "growly": "^1.3.0",
+            "is-wsl": "^1.1.0",
+            "semver": "^5.5.0",
+            "shellwords": "^0.1.1",
+            "which": "^1.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            }
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        },
+        "p-each-series": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+          "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+          "requires": {
+            "p-reduce": "^1.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "parse5": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+          "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
+        "pretty-format": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+          "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "ansi-regex": "^4.0.0",
+            "ansi-styles": "^3.2.0",
+            "react-is": "^16.8.4"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+          "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+          "requires": {
+            "find-up": "^3.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
+        },
+        "stack-utils": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+          "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
+        },
+        "string-length": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+          "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+          "requires": {
+            "astral-regex": "^1.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "test-exclude": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+          "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+          "requires": {
+            "glob": "^7.1.3",
+            "minimatch": "^3.0.4",
+            "read-pkg-up": "^4.0.0",
+            "require-main-filename": "^2.0.0"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.1.6",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+              "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
+          }
+        },
+        "throat": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+          "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+        },
+        "whatwg-url": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+          "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+          "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -7995,6 +9299,11 @@
         "invert-kv": "^1.0.0"
       }
     },
+    "left-pad": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -8787,6 +10096,15 @@
         "has": "^1.0.3"
       }
     },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
+    },
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -8915,6 +10233,11 @@
       "requires": {
         "aggregate-error": "^3.0.0"
       }
+    },
+    "p-reduce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
     },
     "p-try": {
       "version": "1.0.0",
@@ -9101,6 +10424,11 @@
       "requires": {
         "semver-compare": "^1.0.0"
       }
+    },
+    "pn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -9511,6 +10839,14 @@
         "picomatch": "^2.0.7"
       }
     },
+    "realpath-native": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+      "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+      "requires": {
+        "util.promisify": "^1.0.0"
+      }
+    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -9911,6 +11247,11 @@
         }
       }
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -10026,8 +11367,7 @@
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "optional": true
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
     },
     "side-channel": {
       "version": "1.0.2",
@@ -10645,11 +11985,6 @@
         }
       }
     },
-    "text-field-edit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/text-field-edit/-/text-field-edit-3.1.0.tgz",
-      "integrity": "sha512-4mVLiSRR5/p0Zhdl8QkjkUeYUDMSQSYdKsEgR6uOySjcc6QB/O2hzuUlxepL2kQQL0NrpYiI6Ywj6TZULYI9/w=="
-    },
     "test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -10674,6 +12009,11 @@
           }
         }
       }
+    },
+    "text-field-edit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/text-field-edit/-/text-field-edit-3.1.0.tgz",
+      "integrity": "sha512-4mVLiSRR5/p0Zhdl8QkjkUeYUDMSQSYdKsEgR6uOySjcc6QB/O2hzuUlxepL2kQQL0NrpYiI6Ywj6TZULYI9/w=="
     },
     "text-table": {
       "version": "0.2.0",
@@ -11371,6 +12711,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "util.promisify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
+      "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.2",
+        "has-symbols": "^1.0.1",
+        "object.getownpropertydescriptors": "^2.1.0"
+      }
     },
     "uuid": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "fmap-null-undefined": "^1.0.1",
     "husky": "^3.1.0",
     "jest": "^26.1.0",
+    "jest-function": "^1.0.1",
     "lines-unlines": "^1.0.0",
     "milliseconds": "^1.0.3",
     "mousetrap": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "mousetrap": "^1.6.3",
     "preact": "^8.3.0",
     "repository-check-dirty": "^1.0.3",
+    "text-field-edit": "^3.1.0",
     "ts-preferences": "^2.0.0",
     "ts-storage": "^5.0.1",
     "ts-type-guards": "^0.6.1",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,15 +1,29 @@
-export function supportsExecCommand(userAgent: string): boolean {
+export function supportsUndo(userAgent: string): boolean {
     /*
-    Hard to know for sure, but Gecko browsers don't support it as of 2020-07-18 (Firefox 78).
+    Hard to know for sure, but Gecko browsers don't support document.execCommand as of 2020-07-18 (Firefox 78).
     https://bugzilla.mozilla.org/show_bug.cgi?id=1220696
     "Why not use feature detection?" Because document.execCommand can't be feature-detected:
 
         "Note: Only returns true if part of a user interaction. Don't try using the return value to verify browser support before calling a command."
 
     https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#Return_value
+
+    Android doesn't support undo in general.
     */
 
     // Make sure the preference labels referencing this function match the implementation.
-    return !/Gecko\/\d{8}/.test(userAgent);
+    return ![
+        // Having functions, rather than their return values, in this list means we can reap the full benefits of short-circuiting (however important that may or may not be).
+        isGecko,
+        isAndroid,
+    ].some(f => f(userAgent));
+}
+
+export function isGecko(userAgent: string): boolean {
     // Many browsers have "Gecko" in their user agent strings, but I believe only Gecko ones have the eight-digit suffix.
+    return /Gecko\/\d{8}/.test(userAgent);
+}
+
+export function isAndroid(userAgent: string): boolean {
+    return userAgent.includes("Android ");
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,15 @@
+export function supportsExecCommand(userAgent: string): boolean {
+    /*
+    Hard to know for sure, but Gecko browsers don't support it as of 2020-07-18 (Firefox 78).
+    https://bugzilla.mozilla.org/show_bug.cgi?id=1220696
+    "Why not use feature detection?" Because document.execCommand can't be feature-detected:
+
+        "Note: Only returns true if part of a user interaction. Don't try using the return value to verify browser support before calling a command."
+
+    https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#Return_value
+    */
+
+    // Make sure the preference labels referencing this function match the implementation.
+    return !/Gecko\/\d{8}/.test(userAgent);
+    // Many browsers have "Gecko" in their user agent strings, but I believe only Gecko ones have the eight-digit suffix.
+}

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -47,6 +47,10 @@ import insertWebSearchButton from "./operations/web-search-button";
 
 const ALWAYS = true;
 
+// True here means the user wants us to act as if there is undo support (i.e. take no precautions to protect data).
+// Chrome always has actual undo support and Firefox never does.
+const undoSupport = Preferences.get(P.advanced._.undo_support);
+
 const OPERATIONS: readonly Operation<any>[] = [
     operation({
         description: "set document id",
@@ -91,7 +95,7 @@ const OPERATIONS: readonly Operation<any>[] = [
             searchFieldInput: SELECTOR.searchFieldInput,
             searchFieldWrapper: SELECTOR.searchFieldWrapper,
         },
-        action: insertWebSearchButton,
+        action: insertWebSearchButton(undoSupport),
     }),
     operation({
         description: "manage caret position in textarea",
@@ -113,13 +117,13 @@ const OPERATIONS: readonly Operation<any>[] = [
         description: "insert editing tools",
         condition: () => isInEditMode && Preferences.get(P.editing_tools._.enable),
         dependencies: { textarea: SELECTOR.textarea },
-        action: insertEditingTools,
+        action: insertEditingTools(undoSupport),
     }),
     operation({
         description: "insert editing tools in quick reply form",
         condition: () => isReadingThread && Preferences.get(P.editing_tools._.enable) && Preferences.get(P.editing_tools._.in_quick_reply_form),
         dependencies: { textarea: SELECTOR.textarea },
-        action: insertEditingTools,
+        action: insertEditingTools(undoSupport),
     }),
     operation({
         description: "insert heading toolbar button",
@@ -128,7 +132,7 @@ const OPERATIONS: readonly Operation<any>[] = [
             textarea: SELECTOR.textarea,
             strikeButton: SELECTOR.textareaToolbarStrikeButton,
         },
-        action: insertHeadingToolbarButton,
+        action: insertHeadingToolbarButton(undoSupport),
     }),
     operation({
         description: "insert table toolbar button",
@@ -137,7 +141,7 @@ const OPERATIONS: readonly Operation<any>[] = [
             textarea: SELECTOR.textarea,
             unorderedListButton: SELECTOR.textareaToolbarUnorderedListButton,
         },
-        action: insertTableToolbarButton,
+        action: insertTableToolbarButton(undoSupport),
     }),
     operation({
         description: "insert textarea size toggle",
@@ -261,7 +265,7 @@ const OPERATIONS: readonly Operation<any>[] = [
             textarea: SELECTOR.textarea,
             toolbarInner: SELECTOR.textareaToolbarInner,
         },
-        action: autosaveDraft.manageAutosaveWatchdog,
+        action: autosaveDraft.manageAutosaveWatchdog(undoSupport),
     }),
     operation({
         description: "delete any obsolete autosaved draft",

--- a/src/operations/autosave-draft.ts
+++ b/src/operations/autosave-draft.ts
@@ -105,12 +105,12 @@ function maybeOfferToRestoreAutosavedPost(textarea: HTMLTextAreaElement, toolbar
             label: T.general.restore_draft_label,
             tooltip: T.general.restore_draft_tooltip,
             class: CONFIG.CLASS.button_restoreDraft,
-            action: (textarea, undoSupport) => {
+            action: (textarea, _) => {
                 const draftPreview = shortenedIfLongerThan(MAX_LENGTH_TO_SHOW, saved.value);
                 const question_restore = T.general.restore_draft_question + "\n\n" + draftPreview;
                 if (confirm(question_restore)) {
-                    // Avoid overwriting current textarea content in the absence of undo support:
-                    if (undoSupport || textarea.value === "" || confirm(T.general.restore_draft_confirm)) { // `confirm` is problematic in Chrome (see docs/dialogs.md), but Chrome has full undo support.
+                    // Avoid overwriting current textarea content:
+                    if (textarea.value === "" || confirm(T.general.restore_draft_confirm)) {
                         textarea.select();
                         insertIn(textarea, { string: saved.value, replace: true }); // Not replacing would be confusing. Firefox users are protected by the confirmation dialog above.
                         removeRestoreButton();

--- a/src/operations/editing-tools.tsx
+++ b/src/operations/editing-tools.tsx
@@ -12,14 +12,14 @@ import * as T from "~src/text";
 import { BUTTON, BUTTONS, Button, COLORS, colorButton, insertButton, smileyButton, tagButton } from "./logic/editing-tools";
 import { SMILEYS } from "./logic/smileys";
 
-export default (e: { textarea: HTMLElement }) => {
+export default (undoSupport: boolean) => (e: { textarea: HTMLElement }) => {
     const textarea = e.textarea;
     const position = Preferences.get(P.editing_tools._.position);
     const reference = position === Position.ABOVE ? textarea : textarea.nextSibling;
     const toolbar = document.createElement("div");
     const textareaParent = textarea.parentElement as HTMLElement;
     textareaParent.insertBefore(toolbar, reference);
-    render(<EditingTools textarea={textarea as HTMLTextAreaElement} config={getEditingToolsConfig()} />, textareaParent, toolbar);
+    render(<EditingTools textarea={textarea as HTMLTextAreaElement} config={getEditingToolsConfig()} undoSupport={undoSupport} />, textareaParent, toolbar);
 }
 
 interface EditingToolsConfig {
@@ -55,9 +55,10 @@ export function EditingTools(props: {
     textarea: HTMLTextAreaElement,
     disabled?: boolean,
     config: EditingToolsConfig,
+    undoSupport: boolean,
 }): JSX.Element {
     // A "connected" button has been connected to the textarea.
-    const connected = (b: Button) => b(props.textarea);
+    const connected = (b: Button) => b(props.textarea, props.undoSupport);
     const connectedTagButton = compose(connected, tagButton);
     const connectedInsertButton = compose(connected, insertButton);
     const connectedColorButton = compose(connected, colorButton);

--- a/src/operations/heading-toolbar-button.tsx
+++ b/src/operations/heading-toolbar-button.tsx
@@ -6,11 +6,11 @@ import * as T from "~src/text";
 import { toolbarButton } from "./logic/editing-tools";
 import { wrap_tag } from "./logic/textarea";
 
-export default (e: {
+export default (undoSupport: boolean) => (e: {
     textarea: HTMLElement,
     strikeButton: HTMLElement,
 }) => {
-    render(headingToolbarButton(e.textarea as HTMLTextAreaElement), e.strikeButton.parentElement as HTMLElement);
+    render(headingToolbarButton(e.textarea as HTMLTextAreaElement, undoSupport), e.strikeButton.parentElement as HTMLElement);
 }
 
 const headingToolbarButton = toolbarButton({

--- a/src/operations/logic/editing-tools.tsx
+++ b/src/operations/logic/editing-tools.tsx
@@ -318,7 +318,8 @@ const CONSECUTIVE_SPACES = / +/g;
 
 function ACTION_REPLACE_SPACES_WITH_NBSPS(textarea: HTMLTextAreaElement, undoSupport: boolean) {
     const selectedText = selectedTextIn(textarea);
-    if (undoSupport || isOKToReplaceSpacesIrrevocably(selectedText)) {
+    let n: false | number; // Lets us short-circuit with undo support.
+    if (undoSupport || (n = nbspsConfirmationNeeded(selectedText), n === false) || confirm(T.general.nbsps_confirm(n))) { // `confirm` is problematic in Chrome (see docs/dialogs.md), but Chrome has full undo support.
         insertIn(textarea, {
             string: selectedText.replace(SPACE, CONFIG.NBSP),
             replace: true,
@@ -326,13 +327,8 @@ function ACTION_REPLACE_SPACES_WITH_NBSPS(textarea: HTMLTextAreaElement, undoSup
     }
 }
 
-function isOKToReplaceSpacesIrrevocably(selectedText: string): boolean {
-    const n = needsConfirmation(selectedText);
-    return n === false || confirm(T.general.nbsps_confirm(n)); // `confirm` is problematic in Chrome (see docs/dialogs.md), but Chrome has full undo support.
-}
-
 // A heuristic intended to catch cases when the user likely didn't mean to replace spaces with NBSPs and/or it would be cumbersome to restore the change without undo support.
-function needsConfirmation(selectedText: string): false | number {
+function nbspsConfirmationNeeded(selectedText: string): false | number {
     const numberOfSelectedSpaces = selectedText.match(SPACE)?.length || 0;
     const numberOfSelectedSpaceSegments = selectedText.match(CONSECUTIVE_SPACES)?.length || 0;
     // Replacing a large number of spread-out spaces with NBSPs is both uncommon and time-consuming to restore.

--- a/src/operations/logic/editing-tools.tsx
+++ b/src/operations/logic/editing-tools.tsx
@@ -313,25 +313,9 @@ function ACTION_SPLIT_QUOTE(textarea: HTMLTextAreaElement, undoSupport: boolean)
     }
 }
 
-const SPACE = / /g;
-const CONSECUTIVE_SPACES = / +/g;
-
-function ACTION_REPLACE_SPACES_WITH_NBSPS(textarea: HTMLTextAreaElement, undoSupport: boolean) {
-    const selectedText = selectedTextIn(textarea);
-    let n: false | number; // Lets us short-circuit with undo support.
-    if (undoSupport || (n = nbspsConfirmationNeeded(selectedText), n === false) || confirm(T.general.nbsps_confirm(n))) { // `confirm` is problematic in Chrome (see docs/dialogs.md), but Chrome has full undo support.
-        insertIn(textarea, {
-            string: selectedText.replace(SPACE, CONFIG.NBSP),
-            replace: true,
-        });
-    }
-}
-
-// A heuristic intended to catch cases when the user likely didn't mean to replace spaces with NBSPs and/or it would be cumbersome to restore the change without undo support.
-function nbspsConfirmationNeeded(selectedText: string): false | number {
-    const numberOfSelectedSpaces = selectedText.match(SPACE)?.length || 0;
-    const numberOfSelectedSpaceSegments = selectedText.match(CONSECUTIVE_SPACES)?.length || 0;
-    // Replacing a large number of spread-out spaces with NBSPs is both uncommon and time-consuming to restore.
-    const confirmationNeeded = numberOfSelectedSpaces > 10 && numberOfSelectedSpaceSegments > 3
-    return confirmationNeeded ? numberOfSelectedSpaces : false;
+function ACTION_REPLACE_SPACES_WITH_NBSPS(textarea: HTMLTextAreaElement, _: boolean) {
+    insertIn(textarea, {
+        string: selectedTextIn(textarea).replace(/ /g, CONFIG.NBSP),
+        replace: true,
+    });
 }

--- a/src/operations/logic/editing-tools.tsx
+++ b/src/operations/logic/editing-tools.tsx
@@ -43,7 +43,7 @@ export const BUTTON = {
         label: T.editing_tools.label_shibe,
         tooltip: T.editing_tools.tooltip_shibe,
         class: CONFIG.CLASS.shibe,
-        action: textarea => insertIn(textarea, { string: shibeText(selectedTextIn(textarea)), replace: true }),
+        action: (textarea, _) => insertIn(textarea, { string: shibeText(selectedTextIn(textarea)), replace: true }),
     }),
     doge: generalButton({
         tooltip: T.editing_tools.tooltip_doge,
@@ -147,7 +147,7 @@ type ButtonDescription = Readonly<{
 
 type TagButtonDescription = Pick<ButtonDescription, "tag" | "label" | "tooltip" | "class" | "icon" | "parameterized" | "block">
 
-export type Button = (textarea: HTMLTextAreaElement) => JSX.Element
+export type Button = (textarea: HTMLTextAreaElement, undoSupport: boolean) => JSX.Element
 
 export function tagButton(button: TagButtonDescription): Button {
     return generalButton({
@@ -195,7 +195,7 @@ export function smileyButton(smiley: Smileys.Smiley): Button {
 }
 
 export function generalButton(button: Pick<ButtonDescription, "label" | "tooltip" | "class" | "icon" | "custom" | "action" | "style">): Button {
-    return textarea => {
+    return (textarea, undoSupport) => {
         const icon = button.icon;
         const label = (icon === undefined ? "" : icon.type === "URL" ? `<img src="${icon.image}" />` : icon.image) + fromMaybeUndefined("", button.label);
         const className = [
@@ -209,7 +209,7 @@ export function generalButton(button: Pick<ButtonDescription, "label" | "tooltip
                 title={button.tooltip}
                 class={className}
                 style={button.style}
-                onClick={() => button.action(textarea) }
+                onClick={() => button.action(textarea, undoSupport) }
                 href="javascript:void(0)"
             />
         );
@@ -217,13 +217,13 @@ export function generalButton(button: Pick<ButtonDescription, "label" | "tooltip
 }
 
 export function toolbarButton(button: Pick<ButtonDescription, "tooltip" | "class" | "action" | "style">): Button {
-    return textarea => (
+    return (textarea, undoSupport) => (
         <div
             title={button.tooltip}
             class={[ SITE.CLASS.toolbarButton, button.class || "" ].join(" ").trim()}
             style={button.style}
         >
-            <div class={SITE.CLASS.inner} onClick={() => button.action(textarea)}>
+            <div class={SITE.CLASS.inner} onClick={() => button.action(textarea, undoSupport)}>
                 <div class={SITE.CLASS.toolbarButtonIcon}></div>
             </div>
         </div>
@@ -250,10 +250,10 @@ function randomIntBetween(min: number, max: number): number {
     return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-function ACTION_IMG(textarea: HTMLTextAreaElement): void {
+function ACTION_IMG(textarea: HTMLTextAreaElement, undoSupport: boolean): void {
     const selection = selectedTextIn(textarea);
     if (!selection.includes("\n")) {
-        wrap_tag({ tag: SITE.TAG.img, parameterized: false, block: false })(textarea);
+        wrap_tag({ tag: SITE.TAG.img, parameterized: false, block: false })(textarea, undoSupport);
     } else {
         const imgify = (line: string) => line.trim() === "" ? "" : BB.start(SITE.TAG.img) + line.trim() + BB.end(SITE.TAG.img);
         insertIn(textarea, { string: unlines(lines(selection).map(imgify)), replace: true });
@@ -261,7 +261,7 @@ function ACTION_IMG(textarea: HTMLTextAreaElement): void {
 }
 
 function ACTION_SEARCH_LINK(engine: SearchEngine) {
-    return (textarea: HTMLTextAreaElement): void => {
+    return (textarea: HTMLTextAreaElement, _: boolean): void => {
         const tagName = SITE.TAG.url;
         const selected = selectedTextIn(textarea);
         const startTag = BB.start(tagName, searchURL(engine, selected));
@@ -273,26 +273,69 @@ function ACTION_SEARCH_LINK(engine: SearchEngine) {
     }
 }
 
-function ACTION_SPLIT_QUOTE(textarea: HTMLTextAreaElement): void {
-    const emptyLines = "\n".repeat(CONFIG.CONTENT.splitQuoteEmptyLines + 1);
-    const beforeSelection = textarea.value.substring(0, textarea.selectionStart).trimRight();
-    const afterSelection = textarea.value.substring(textarea.selectionEnd).trimLeft();
-    if (new RegExp(r`\[\/${SITE.TAG.quote}\]$`, "i").test(beforeSelection) && new RegExp(r`^\[${SITE.TAG.quote}`, "i").test(afterSelection)) {
-        // Cursor is between two existing quotes, so just insert empty lines and place the cursor accordingly:
-        textarea.value = beforeSelection + emptyLines + afterSelection;
-        placeCursorIn(textarea, beforeSelection.length + 1); // + 1 to get past the first inserted line break
+function ACTION_SPLIT_QUOTE(textarea: HTMLTextAreaElement, undoSupport: boolean): void {
+    // Yes, this code is hard to understand. It was conceived using a considerable amount of trial and error.
+    const beforeSelection = textarea.value.substring(0, textarea.selectionStart);
+    const afterSelection = textarea.value.substring(textarea.selectionEnd);
+    const existingNewlinesBeforeSelection = beforeSelection.match(/\n*$/)![0].length;
+    const existingNewlinesAfterSelection = afterSelection.match(/^\n*/)![0].length;
+    const cursorIsBetweenTwoExistingQuotes = (
+        new RegExp(r`\[\/${SITE.TAG.quote}\]$`, "i").test(beforeSelection.trimRight())
+        &&
+        new RegExp(r`^\[${SITE.TAG.quote}`, "i").test(afterSelection.trimLeft())
+    );
+    if (cursorIsBetweenTwoExistingQuotes) {
+        // Just insert empty lines and place the cursor accordingly.
+        const numberOfNewlinesToInsert = Math.max(
+            0, // Using a negative value with String.prototype.repeat is a RangeError.
+            CONFIG.CONTENT.splitQuoteEmptyLines + 1 - existingNewlinesBeforeSelection - existingNewlinesAfterSelection,
+        );
+        // If there are more newlines than we'd like between the quotes, they will be left untouched, because we don't want to mess with deleting content.
+        insertIn(textarea, {
+            string: "\n".repeat(numberOfNewlinesToInsert),
+            replace: undoSupport,
+        });
+        placeCursorIn(textarea, beforeSelection.length - existingNewlinesBeforeSelection + 1); // + 1 to get past the first line break
     } else {
-        // Cursor is not between two existing quotes, so add quote tags as well:
+        // Add quote tags and place cursor.
         const startTag = BB.start(SITE.TAG.quote);
         const endTag = BB.end(SITE.TAG.quote);
-        textarea.value = beforeSelection + `\n` + endTag + emptyLines + startTag + `\n` + afterSelection;
-        placeCursorIn(textarea, beforeSelection.length + 1 + endTag.length + 1); // + 1 + 1 to get past two line breaks
+        const extraNewlineBeforeSelectionNeeded = existingNewlinesBeforeSelection === 0;
+        const extraNewlineAfterSelectionNeeded = existingNewlinesAfterSelection === 0;
+        insertIn(textarea, { string: [
+            extraNewlineBeforeSelectionNeeded ? "\n" : "",
+            endTag,
+            "\n".repeat(CONFIG.CONTENT.splitQuoteEmptyLines + 1),
+            startTag,
+            extraNewlineAfterSelectionNeeded ? "\n" : "",
+        ].join(""), replace: undoSupport });
+        placeCursorIn(textarea, beforeSelection.length + (extraNewlineBeforeSelectionNeeded ? 1 : 0) + endTag.length + 1); // + 1 to get past a line break
     }
 }
 
-function ACTION_REPLACE_SPACES_WITH_NBSPS(textarea: HTMLTextAreaElement) {
-    insertIn(textarea, {
-        string: selectedTextIn(textarea).replace(/ /g, CONFIG.NBSP),
-        replace: true,
-    });
+const SPACE = / /g;
+const CONSECUTIVE_SPACES = / +/g;
+
+function ACTION_REPLACE_SPACES_WITH_NBSPS(textarea: HTMLTextAreaElement, undoSupport: boolean) {
+    const selectedText = selectedTextIn(textarea);
+    if (undoSupport || isOKToReplaceSpacesIrrevocably(selectedText)) {
+        insertIn(textarea, {
+            string: selectedText.replace(SPACE, CONFIG.NBSP),
+            replace: true,
+        });
+    }
+}
+
+function isOKToReplaceSpacesIrrevocably(selectedText: string): boolean {
+    const n = needsConfirmation(selectedText);
+    return n === false || confirm(T.general.nbsps_confirm(n)); // `confirm` is problematic in Chrome (see docs/dialogs.md), but Chrome has full undo support.
+}
+
+// A heuristic intended to catch cases when the user likely didn't mean to replace spaces with NBSPs and/or it would be cumbersome to restore the change without undo support.
+function needsConfirmation(selectedText: string): false | number {
+    const numberOfSelectedSpaces = selectedText.match(SPACE)?.length || 0;
+    const numberOfSelectedSpaceSegments = selectedText.match(CONSECUTIVE_SPACES)?.length || 0;
+    // Replacing a large number of spread-out spaces with NBSPs is both uncommon and time-consuming to restore.
+    const confirmationNeeded = numberOfSelectedSpaces > 10 && numberOfSelectedSpaceSegments > 3
+    return confirmationNeeded ? numberOfSelectedSpaces : false;
 }

--- a/src/operations/table-toolbar-button.tsx
+++ b/src/operations/table-toolbar-button.tsx
@@ -13,16 +13,16 @@ const enum Headings { NONE, FIRST, ALL }
 const TABLE_CONFIG = { rows: 4, columns: 3, headings: true };
 
 const tableToolbarButton = toolbarButton({
-    action: textarea => insert(table(TABLE_CONFIG))(textarea), // eta-abstracted to defer table generation until button clicked
+    action: (textarea, undoSupport) => insert(table(TABLE_CONFIG))(textarea, undoSupport), // eta-abstracted to defer table generation until button clicked
     class: SITE.CLASS.toolbarTableButton,
     tooltip: T.general.tooltip_table,
 });
 
-export default (e: {
+export default (undoSupport: boolean) => (e: {
     textarea: HTMLElement,
     unorderedListButton: HTMLElement,
 }) => {
-    render(tableToolbarButton(e.textarea as HTMLTextAreaElement), e.unorderedListButton.parentElement as HTMLElement);
+    render(tableToolbarButton(e.textarea as HTMLTextAreaElement, undoSupport), e.unorderedListButton.parentElement as HTMLElement);
 }
 
 function table(config: Readonly<typeof TABLE_CONFIG>): string {

--- a/src/operations/web-search-button.tsx
+++ b/src/operations/web-search-button.tsx
@@ -7,7 +7,7 @@ import * as T from "~src/text";
 
 import { Icon, generalButton } from "./logic/editing-tools";
 
-export default (e: {
+export default (undoSupport: boolean) => (e: {
     searchFieldInput: HTMLElement,
     searchFieldWrapper: HTMLElement,
 }) => {
@@ -19,7 +19,7 @@ export default (e: {
         icon: icon(engine),
     });
     const fakeTextarea = document.createElement("textarea");
-    render(button(fakeTextarea), e.searchFieldWrapper);
+    render(button(fakeTextarea, undoSupport), e.searchFieldWrapper);
 }
 
 function icon(engine: SearchEngine): Icon {

--- a/src/preferences-menu.tsx
+++ b/src/preferences-menu.tsx
@@ -121,6 +121,7 @@ function Entry<T extends AllowedTypes>(generators: Generators, p: Preference<T> 
                         textarea={document.createElement("textarea")}
                         config={getEditingToolsConfig()}
                         disabled={!Preferences.get(P.editing_tools._.enable)}
+                        undoSupport={Preferences.get(P.advanced._.undo_support)}
                     />
                     : null
                 }

--- a/src/preferences/advanced.ts
+++ b/src/preferences/advanced.ts
@@ -4,6 +4,7 @@ import {
     StringPreference,
 } from "ts-preferences";
 
+import * as browser from "~src/browser";
 import * as CONFIG from "~src/config";
 import * as Proofreading from "~src/operations/proofreading";
 import * as T from "~src/text";
@@ -71,6 +72,23 @@ export default {
         default: false,
         label: T.preferences.advanced.proofread_forum_posts,
         description: T.preferences.advanced.proofread_forum_posts_description,
+    }),
+    undo_support: new MultichoicePreference({
+        // Could have been a BooleanPreference, but it was hard to come up with an understandable label and description then.
+        key: "undo_support",
+        default: browser.supportsExecCommand(navigator.userAgent),
+        label: T.preferences.advanced.undo_support.label,
+        description: T.preferences.advanced.undo_support.description,
+        options: [
+            {
+                value: true,
+                label: T.preferences.advanced.undo_support.replace_selected,
+            },
+            {
+                value: false,
+                label: T.preferences.advanced.undo_support.keep_selected,
+            },
+        ],
     }),
     custom_css_enable,
     custom_css_code: new StringPreference({

--- a/src/preferences/advanced.ts
+++ b/src/preferences/advanced.ts
@@ -76,7 +76,7 @@ export default {
     undo_support: new MultichoicePreference({
         // Could have been a BooleanPreference, but it was hard to come up with an understandable label and description then.
         key: "undo_support",
-        default: browser.supportsExecCommand(navigator.userAgent),
+        default: browser.supportsUndo(navigator.userAgent),
         label: T.preferences.advanced.undo_support.label,
         description: T.preferences.advanced.undo_support.description,
         options: [

--- a/src/preferences/editing-tools.ts
+++ b/src/preferences/editing-tools.ts
@@ -9,9 +9,11 @@ import { BUTTONS, Button, insertButton } from "~src/operations/logic/editing-too
 import { SearchEngine } from "~src/search-engines";
 import * as T from "~src/text";
 
+
 function buttonsDescription(buttons: readonly Button[]): string {
     const textarea = document.createElement("textarea");
-    const connectedButtons = buttons.map(b => b(textarea));
+    const undoSupport = true; // The buttons are only used for illustrative purposes, not actual text editing.
+    const connectedButtons = buttons.map(b => b(textarea, undoSupport));
     const div = document.createElement("div");
     for (const b of connectedButtons) {
         render(b, div);

--- a/src/text.ts
+++ b/src/text.ts
@@ -2,6 +2,7 @@
 
 import * as BB from "bbcode-tags";
 
+import * as browser from "./browser";
 import * as CONFIG from "./config";
 import { SearchEngine } from "./search-engines";
 import * as SITE from "./site";
@@ -40,6 +41,7 @@ export const general = {
     restore_draft_tooltip: `Återställ autosparat utkast`,
     restore_draft_question: `Vill du återställa följande utkast?`,
     restore_draft_confirm: `Din nuvarande text kommer ersättas. Är du säker?`,
+    nbsps_confirm: (n: number) => `${n} mellanslag kommer ersättas med hårda mellanslag. Är du säker?`,
     // Copied from SweClockers:
     signout_error: `Ett fel har uppstått och utloggningen misslyckades. Var god ladda om sidan och försök igen. Rensa cookies i din webbläsare för att logga ut manuellt.`,
     quote_signature_label: `Citera sign.`,
@@ -223,6 +225,12 @@ export const preferences = {
         },
         proofread_forum_posts: `Markera möjliga fel i foruminlägg (i redigeringsläge)`,
         proofread_forum_posts_description: `Samma som ovan, fast i forumet`,
+        undo_support: (browser.supportsExecCommand, { // Make sure the labels match the actual support check (referenced here to facilitate a `git grep` search).
+            label: `När ett verktyg infogar text`,
+            description: `Om din webbläsare inte låter dig ångra åtgärder utförda med redigeringsverktygen kan ${CONFIG.USERSCRIPT_NAME} skydda markerad text mot oavsiktlig radering om du råkar trycka på fel knapp`,
+            replace_selected: `Ersätt markerad text – rekommenderas i alla webbläsare med fullgott ångra-stöd`,
+            keep_selected: `Behåll markerad text – rekommenderas i <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1220696">Firefox/Gecko</a>`, // Make sure the text matches the actual support check.
+        }),
         custom_css_enable: `Infoga egen CSS:`,
         custom_css_enable_description: `Anpassa layout och utseende precis som du vill`,
         custom_css_warning: `Klistra aldrig in kod som du inte litar på!`,

--- a/src/text.ts
+++ b/src/text.ts
@@ -225,11 +225,11 @@ export const preferences = {
         },
         proofread_forum_posts: `Markera möjliga fel i foruminlägg (i redigeringsläge)`,
         proofread_forum_posts_description: `Samma som ovan, fast i forumet`,
-        undo_support: (browser.supportsExecCommand, { // Make sure the labels match the actual support check (referenced here to facilitate a `git grep` search).
+        undo_support: (browser.supportsUndo, { // Make sure the labels match the actual support check (referenced here to facilitate a `git grep` search).
             label: `När ett verktyg infogar text`,
             description: `Om din webbläsare inte låter dig ångra åtgärder utförda med redigeringsverktygen kan ${CONFIG.USERSCRIPT_NAME} skydda markerad text mot oavsiktlig radering om du råkar trycka på fel knapp`,
             replace_selected: `Ersätt markerad text – rekommenderas i alla webbläsare med fullgott ångra-stöd`,
-            keep_selected: `Behåll markerad text – rekommenderas i <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1220696">Firefox/Gecko</a>`, // Make sure the text matches the actual support check.
+            keep_selected: `Behåll markerad text – rekommenderas i <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1220696">Firefox/Gecko</a> samt på Android`, // Make sure the text matches the actual support check.
         }),
         custom_css_enable: `Infoga egen CSS:`,
         custom_css_enable_description: `Anpassa layout och utseende precis som du vill`,

--- a/src/text.ts
+++ b/src/text.ts
@@ -41,7 +41,6 @@ export const general = {
     restore_draft_tooltip: `Återställ autosparat utkast`,
     restore_draft_question: `Vill du återställa följande utkast?`,
     restore_draft_confirm: `Din nuvarande text kommer ersättas. Är du säker?`,
-    nbsps_confirm: (n: number) => `${n} mellanslag kommer ersättas med hårda mellanslag. Är du säker?`,
     // Copied from SweClockers:
     signout_error: `Ett fel har uppstått och utloggningen misslyckades. Var god ladda om sidan och försök igen. Rensa cookies i din webbläsare för att logga ut manuellt.`,
     quote_signature_label: `Citera sign.`,


### PR DESCRIPTION
Up until now, we've used `.value` to modify textarea content. This nukes the undo history of the textarea, resulting in very bad UX. A seemingly better (albeit deprecated) way is to use [`document.execCommand`](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand), which interacts well with undo, and fall back to `.value` if that fails. This behavior is provided by the `text-field-edit` package.

Since [Gecko browsers don't support inserting text with `document.execCommand`](https://bugzilla.mozilla.org/show_bug.cgi?id=1220696), this PR adds a preference that lets the user choose whether their data should be protected against accidental deletion (with the downside of unintuitive semantics for some editing tools) or we should assume that they can always undo their changes. The protection is enabled by default in Gecko browsers and disabled in others, except on Android, which usually doesn't support undo at all.

It might be worth investigating [`HTMLTextAreaElement.prototype.setRangeText`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setRangeText) further, although it doesn't look very promising from what I've seen.

Undo support for SweClockers' built-in editing tools is planned for a future PR.

Resolves #43.