### PR TITLE
Move SearchEngine to the search-engines module

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -116,8 +116,4 @@ export const ICONS = {
 
 export const FOCUSABLE_ELEMENTS = [ "textarea", "input", "select" ] as const;
 
-export const enum SearchEngine {
-    // Be careful! These strings are used in the UI.
-    GOOGLE = "Google",
-    DUCKDUCKGO = "DuckDuckGo",
-}
+export { SearchEngine } from "./search-engines";

--- a/src/search-engines.ts
+++ b/src/search-engines.ts
@@ -1,5 +1,8 @@
-import { SearchEngine } from "~src/config";
-export { SearchEngine } from "~src/config";
+export const enum SearchEngine {
+    // Be careful! These strings are used in the UI.
+    GOOGLE = "Google",
+    DUCKDUCKGO = "DuckDuckGo",
+}
 
 function searchEngineURL(engine: SearchEngine): string {
     switch (engine) {


### PR DESCRIPTION
I wanted to add the no-duplicate-imports lint rule, with `"includeExports": true`, but doing so caused an error:

    '~src/config' export is duplicated as import

The most obvious attempt at fixing this would be

```diff
-export { SearchEngine } from "~src/config";
+export { SearchEngine };
```

but that doesn't work:

    ERROR in ./src/search-engines.ts 1:9
    Module parse failed: Export 'SearchEngine' is not defined (1:9)
    File was processed with these loaders:
     * ./node_modules/awesome-typescript-loader/dist/entry.js
     * ./node_modules/restrict-imports-loader/dist/index.js
    You may need an additional loader to handle the result of these loaders.
    > export { SearchEngine };
    | function searchEngineURL(engine) {
    |     switch (engine) {
     @ ./src/operations/web-search-button.tsx 3:0-60 22:16-25 22:34-44
     @ ./src/operations.ts
     @ ./src/main.ts

Anyway, I feel like `SearchEngine` belongs in the `search-engines` module.