### PR TITLE
Add no-duplicate-imports lint rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,6 +5,7 @@ extends:
 root: true
 rules:
     "no-unused-vars": 0 # Should be turned off when using @typescript-eslint.
+    "no-duplicate-imports": [ "error", { "includeExports": true } ]
     "@typescript-eslint/no-explicit-any": 0
     "@typescript-eslint/no-namespace": [ 2, { "allowDeclarations": true } ] # We declare namespaces for host site APIs.
     "@typescript-eslint/no-unused-vars": [ 2, { "argsIgnorePattern": "^_" } ]


### PR DESCRIPTION
In addition to the rationale given in [the docs][docs], this protects
against nasty bugs like

    import ACTION_FOO from "./foo";
    import ACTION_BAR from "./foo";

which could easily go completely unnoticed.

[docs]: https://eslint.org/docs/rules/no-duplicate-imports