### PR TITLE
Suppress eslint-plugin-react version warning

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -33,4 +33,4 @@ rules:
 settings:
     react:
         pragma: h
-        version: detect
+        version: latest


### PR DESCRIPTION
For the record, I don't really know what it means to specify a React version.