### PR TITLE
Use CI instead of nightly builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,13 @@
-name: Nightly
+name: CI
 
 on:
-  schedule:
-    - cron: '0 2 * * *'
+  push:
+    branches:
+      - master
 
 jobs:
   nightly:
-    name: Nightly Build
+    name: CI Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -1,9 +1,7 @@
 name: Validation
 
 on:
-  push:
-    branches:
-      - master
+  # CI workflow is responsible for building on push to master.
   pull_request:
     branches:
       - master


### PR DESCRIPTION
BSC Nightly users shouldn't have to wait until the next day before they
get access to updates. Also, my activity feed on GitHub was spammed with
notifications about github-actions (bot) pushing to the gh-pages branch.