### PR TITLE
Fix marvinpinto's release action dependency

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
           BRANCH: gh-pages
           FOLDER: dist
       - name: Create GitHub release
-        uses: marvinpinto/action-automatic-releases@v1.0.0
+        uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false


### PR DESCRIPTION
When I tried to release v3.17.0, I ran into these errors:

    ##[error]marvinpinto/action-automatic-releases/v1.0.0/action.yml (Line: 27, Col: 5): Unexpected value 'decription'
    ##[error]marvinpinto/action-automatic-releases/v1.0.0/action.yml (Line: 27, Col: 5): Unexpected value 'decription'
    ##[error]Fail to load marvinpinto/action-automatic-releases/v1.0.0/action.yml

I don't know why the v3.16.0 release worked, because it also used v1.0.0
of marvinpinto's action. `¯\_(ツ)_/¯` But [I'm not alone][pr], and
@TomerFi might be on to something:

> I'm guessing GitHub started validating these action files today or
> something.

Issue was fixed [two weeks ago][fix], but it seems like we're gonna have
to go with the `latest` tag in the absence of a new SemVer release.

[pr]: https://github.com/marvinpinto/action-automatic-releases/pull/1
[fix]: https://github.com/marvinpinto/action-automatic-releases/commit/8d9ddb2546e687f72855285d2719a11709cea6d0