### PR TITLE
Migrate Nightly users to "stable"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,6 @@ jobs:
           npm run build
         env:
           CI: true
-          USERSCRIPTER_HOSTED_AT: https://${{ github.repository_owner }}.github.io/better-sweclockers/nightly # Must match TARGET_FOLDER.
           USERSCRIPTER_MODE: production
           USERSCRIPTER_NIGHTLY: true
           USERSCRIPTER_VERBOSE: true
@@ -39,4 +38,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: dist
-          TARGET_FOLDER: nightly # Must match USERSCRIPTER_HOSTED_AT.
+          TARGET_FOLDER: nightly


### PR DESCRIPTION
I've decided to abandon the concept of nightly builds, because it hasn't
worked out very well. In particular, I tend to forget that I should
issue new "stable" releases. The nature and number of users of BSC also
don't really justify the complexity of "nightly" and "stable" builds.

And yeah: https://www.sweclockers.com/forum/post/17698684 :roll_eyes: 

This PR should ensure that current BSC Nightly users are automatically
migrated to "stable".