### PR TITLE
Remove support for Blargmode's dark theme

### DIFF
--- a/src/dark-theme.ts
+++ b/src/dark-theme.ts
@@ -1,34 +1,6 @@
-import darkThemeAdditionsBlargmode from "~src/stylesheets/dark-theme-additions-blargmode.scss";
-
-export const enum Source {
-    // Be careful! These strings are used in the UI.
-    BLARGMODE = "Blargmode",
-    SOITORA = "Soitora",
-}
-
-export function darkThemeUrl(source: Source): string {
-    switch (source) {
-        case Source.BLARGMODE: return "https://blargmode.se/files/swec_dark_theme/style.css";
-        case Source.SOITORA: return "https://soitora.com/SweClockers-Dark/sweclockers-dark.min.css";
-    }
-}
-
-export function darkThemeInfoUrl(source: Source): string {
-    switch (source) {
-        case Source.BLARGMODE: return "/forum/trad/1089561";
-        case Source.SOITORA: return "/forum/trad/1515628";
-    }
-}
-
-export function darkThemeAdditions(source: Source): string {
-    switch (source) {
-        case Source.BLARGMODE:
-            return darkThemeAdditionsBlargmode;
-        default:
-            return "";
-    }
-}
-
-export function darkThemeUrlBackup(source: Source): string {
-    return `https://simonalling.se/userscripts/better-sweclockers/dark-theme-${source.toLowerCase()}.css`;
-}
+export const AUTHOR = "Soitora" as const;
+export const URL = {
+    canonical: "https://soitora.com/SweClockers-Dark/sweclockers-dark.min.css",
+    backup: `https://simonalling.se/userscripts/better-sweclockers/dark-theme-${AUTHOR.toLowerCase()}.css`,
+    info: "/forum/trad/1515628",
+} as const;

--- a/src/operations/dark-theme.ts
+++ b/src/operations/dark-theme.ts
@@ -3,7 +3,7 @@ import { render } from "preact";
 import { isNull } from "ts-type-guards";
 
 import * as CONFIG from "~src/config";
-import { darkThemeAdditions, darkThemeUrl, darkThemeUrlBackup } from "~src/dark-theme";
+import * as darkTheme from "~src/dark-theme";
 import { P, Preferences } from "~src/preferences";
 import * as T from "~src/text";
 import { timeIsWithin } from "~src/time";
@@ -13,9 +13,8 @@ import { tab } from "./logic/topMenuTab";
 
 export function insertToggle(e: { topMenu: HTMLElement }): void {
     const state = Preferences.get(P.dark_theme._.active);
-    const source = Preferences.get(P.dark_theme._.source);
     const button = tab({
-        title: state ? T.general.dark_theme_toggle_tooltip_off : T.general.dark_theme_toggle_tooltip_on(source),
+        title: state ? T.general.dark_theme_toggle_tooltip_off : T.general.dark_theme_toggle_tooltip_on(darkTheme.AUTHOR),
         id: CONFIG.ID.darkThemeToggle,
         classes: state ? [CONFIG.CLASS.darkThemeActive] : [],
         link: {
@@ -36,20 +35,15 @@ export function manage(): void {
 }
 
 function apply(newState: boolean): void {
-    const source = Preferences.get(P.dark_theme._.source);
-    const url = Preferences.get(P.dark_theme._.use_backup) ? darkThemeUrlBackup : darkThemeUrl;
+    const url = Preferences.get(P.dark_theme._.use_backup) ? darkTheme.URL.backup : darkTheme.URL.canonical;
     if (newState) {
         if (isNull(document.getElementById(CONFIG.ID.darkThemeStylesheet))) {
             // Not document.head because it can be null, e.g. in a background tab in Firefox:
             const link = document.createElement("link");
             link.rel = "stylesheet";
-            link.href = url(source);
+            link.href = url;
             link.id = CONFIG.ID.darkThemeStylesheet;
             document.documentElement.appendChild(link);
-            const style = document.createElement("style");
-            style.textContent = darkThemeAdditions(source);
-            style.id = CONFIG.ID.darkThemeAdditions;
-            document.documentElement.appendChild(style);
         }
     } else {
         withMaybe(document.getElementById(CONFIG.ID.darkThemeStylesheet), element => element.remove());
@@ -57,7 +51,7 @@ function apply(newState: boolean): void {
     withMaybe(document.getElementById(CONFIG.ID.darkThemeToggle), toggle => {
         const active = CONFIG.CLASS.darkThemeActive;
         newState ? toggle.classList.add(active) : toggle.classList.remove(active);
-        toggle.title = newState ? T.general.dark_theme_toggle_tooltip_off : T.general.dark_theme_toggle_tooltip_on(source);
+        toggle.title = newState ? T.general.dark_theme_toggle_tooltip_off : T.general.dark_theme_toggle_tooltip_on(darkTheme.AUTHOR);
     });
 }
 

--- a/src/operations/logic/editing-tools.tsx
+++ b/src/operations/logic/editing-tools.tsx
@@ -180,7 +180,7 @@ export function colorButton(color: string): Button {
     return generalButton({
         label: "",
         tooltip: color,
-        style: `background: ${color} !important;`, // !important to override Blargmode
+        style: `background: ${color};`,
         action: wrap_verbatim({
             before: BB.start(SITE.TAG.color, color),
             after: BB.end(SITE.TAG.color),

--- a/src/preferences-menu.tsx
+++ b/src/preferences-menu.tsx
@@ -114,7 +114,7 @@ function Entry<T extends AllowedTypes>(generators: Generators, p: Preference<T> 
                     )
             ) : (
                 <fieldset class={SITE.CLASS.fieldset}>
-                    <legend>{p.label}</legend>
+                    <HtmlLegend html={p.label} />
                     {Entries(generators, p._)}
                     {
                         p.extras && p.extras.id === CONFIG.ID.editingToolsPreferences
@@ -438,5 +438,11 @@ class PreferenceLabel<T extends AllowedTypes> extends Component<{ preference: Pr
 class HtmlLabel extends Component<{ html: string, for?: string }> {
     public render() {
         return <label for={this.props.for} dangerouslySetInnerHTML={{ __html: this.props.html }} />;
+    }
+}
+
+class HtmlLegend extends Component<{ html: string }> {
+    public render() {
+        return <legend dangerouslySetInnerHTML={{ __html: this.props.html }}></legend>;
     }
 }

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -2,6 +2,7 @@ import { PreferenceManager } from "ts-preferences";
 import { loggingResponseHandler, subscriptable } from "userscripter/lib/preferences";
 
 import * as CONFIG from "~src/config";
+import * as darkTheme from "~src/dark-theme";
 import * as T from "~src/text";
 import U from "~src/userscript";
 
@@ -34,7 +35,7 @@ export const P = {
         extras: { id: CONFIG.ID.editingToolsPreferences },
     },
     dark_theme: {
-        label: T.preferences.dark_theme.label,
+        label: T.preferences.dark_theme.label(darkTheme.AUTHOR, darkTheme.URL.info),
         _: darkThemePreferences,
     },
     advanced: {

--- a/src/preferences/dark-theme.ts
+++ b/src/preferences/dark-theme.ts
@@ -2,11 +2,9 @@ import * as ms from "milliseconds";
 import {
     BooleanPreference,
     IntegerRangePreference,
-    MultichoicePreference,
 } from "ts-preferences";
 
 import * as CONFIG from "~src/config";
-import { Source, darkThemeInfoUrl } from "~src/dark-theme";
 import * as T from "~src/text";
 
 import { TimePreference } from "./TimePreference";
@@ -26,10 +24,6 @@ const dependencies_auto = [
     },
 ];
 
-function label(source: Source): string {
-    return T.preferences.dark_theme.source.option(source, darkThemeInfoUrl(source));
-}
-
 export default {
     active: new BooleanPreference({
         key: "dark_theme_active",
@@ -42,22 +36,6 @@ export default {
         default: false,
         label: T.preferences.NO_LABEL,
         extras: { implicit: true },
-    }),
-    source: new MultichoicePreference<Source>({
-        key: "dark_theme_source",
-        default: Source.BLARGMODE,
-        options: [
-            {
-                value: Source.BLARGMODE,
-                label: label(Source.BLARGMODE),
-            },
-            {
-                value: Source.SOITORA,
-                label: label(Source.SOITORA),
-            },
-        ],
-        label: T.preferences.dark_theme.source.label,
-        description: T.preferences.dark_theme.source.description,
     }),
     show_toggle: new BooleanPreference({
         key: "dark_theme_show_toggle",

--- a/src/stylesheets/dark-theme-additions-blargmode.scss
+++ b/src/stylesheets/dark-theme-additions-blargmode.scss
@@ -1,7 +1,0 @@
-##{getGlobal("CONFIG.ID.document")} {
-
-.bg-orange a {
-    color: #e7e5e1 !important; // "Kommentarer till artikeln"; https://www.sweclockers.com/forum/post/18279784
-}
-
-}

--- a/src/stylesheets/dark-theme-toggle.scss
+++ b/src/stylesheets/dark-theme-toggle.scss
@@ -6,9 +6,8 @@
 }
 
 ##{getGlobal("CONFIG.ID.darkThemeToggle")}.#{getGlobal("CONFIG.CLASS.darkThemeActive")} {
-    // !important to override Blargmode's dark theme:
-    background-color: #dfdfdf !important;
-    background-image: none !important;
+    background-color: #dfdfdf;
+    background-image: none;
 }
 
 ##{getGlobal("CONFIG.ID.darkThemeToggle")}:hover, ##{getGlobal("CONFIG.ID.darkThemeToggle")}:focus {

--- a/src/stylesheets/doge.scss
+++ b/src/stylesheets/doge.scss
@@ -1,7 +1,7 @@
 ##{getGlobal("CONFIG.ID.document")} {
 
 .#{getGlobal("CONFIG.CLASS.shibe")}, .#{getGlobal("CONFIG.CLASS.shibe")} * {
-    color: #{getGlobal("CONFIG.CONTENT.shibeColor")} !important; // to override Blargmode
+    color: #{getGlobal("CONFIG.CONTENT.shibeColor")};
     font-family: #{getGlobal("CONFIG.CONTENT.shibeFont")};
     font-style: italic;
     white-space: pre;

--- a/src/stylesheets/editing-tools.scss
+++ b/src/stylesheets/editing-tools.scss
@@ -90,7 +90,7 @@
     $RAINBOW_OPACITY: 0.7;
     $RAINBOW: linear-gradient(to right, rgba(255,0,0,$RAINBOW_OPACITY) 0%,rgba(255,153,50,$RAINBOW_OPACITY) 16%,rgba(247,227,49,$RAINBOW_OPACITY) 33%,rgba(62,211,42,$RAINBOW_OPACITY) 49%,rgba(46,117,232,$RAINBOW_OPACITY) 66%,rgba(90,45,226,$RAINBOW_OPACITY) 83%,rgba(152,25,198,$RAINBOW_OPACITY) 100%);
     .#{getGlobal("CONFIG.CLASS.button_color")} {
-        background: $FADE, $RAINBOW !important; // to override Blargmode
+        background: $FADE, $RAINBOW;
     }
     .#{getGlobal("CONFIG.CLASS.button_color")}:hover, .#{getGlobal("CONFIG.CLASS.button_color")}:focus {
         background: $FADE_BRIGHT, $RAINBOW !important;
@@ -108,7 +108,7 @@
 
     $COLOR_SPOILER: #222;
     .#{getGlobal("CONFIG.CLASS.button_spoiler")} {
-        background: $FADE, $COLOR_SPOILER !important; // to override Blargmode
+        background: $FADE, $COLOR_SPOILER;
         color: #eee;
         border-color: black;
     }

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -52,7 +52,7 @@ textarea.#{getGlobal("CONFIG.CLASS.codeInput")}, .#{getGlobal("CONFIG.CLASS.code
 }
 
 ##{getGlobal("CONFIG.ID.preferencesShortcut")} {
-    background-image: url("#{getGlobal("SITE.URL_ICONS_GENERAL")}") !important; // to override Blargmode
+    background-image: url("#{getGlobal("SITE.URL_ICONS_GENERAL")}");
     background-position: -165px -95px;
     background-size: 600px auto; // scale down 2x; image is 1200px wide
     margin-left: #{getGlobal("SITE.EXTRA_TAB_MARGIN")};

--- a/src/stylesheets/replace-followed-threads-link.scss
+++ b/src/stylesheets/replace-followed-threads-link.scss
@@ -5,7 +5,7 @@
 
     // Prevent orange link from flashing briefly before being replaced:
     &, & a.label {
-        color: unset !important; // to override Blargmode
+        color: unset;
         font-weight: unset;
     }
 }

--- a/src/text.ts
+++ b/src/text.ts
@@ -12,8 +12,6 @@ function genitive(name: string): string {
     return ["s", "x", "z"].some(letter => name.endsWith(letter)) ? name : name + "s";
 }
 
-// string is used instead of Source here because this file cannot import modules containing Webpack-resolved imports.
-// The dark-theme module imports a SASS module, which is a Webpack-resolved import even with a relative path.
 function darkThemeBy(author: string): string {
     return `${genitive(author)} mörka tema`;
 }
@@ -170,12 +168,7 @@ export const preferences = {
     },
 
     dark_theme: {
-        label: `Mörkt tema`,
-        source: {
-            label: `Tema`,
-            description: `Vilket mörkt tema föredrar du?`,
-            option: (name: string, infoUrl: string) => `${name} (<a target="_blank" href="${infoUrl}">forumtråd</a>)`,
-        },
+        label: (author: string, infoUrl: string) => `${darkThemeBy(author)} (<a target="_blank" href="${infoUrl}">forumtråd</a>)`,
         show_toggle: `Visa knapp för manuell växling`,
         show_toggle_description: `Toggla manuellt det mörka temat med en knapp högst upp på sidan`,
         auto: `Automatisk aktivering`,
@@ -185,7 +178,7 @@ export const preferences = {
         interval: `Uppdateringsintervall`,
         interval_description: `Hur ofta ${CONFIG.USERSCRIPT_NAME} ska kolla vad klockan är`,
         use_backup: `Använd Allings server`,
-        use_backup_description: `Workaround om ditt valda mörka tema inte är tillgängligt "live"`,
+        use_backup_description: `Workaround om det mörka temat inte är tillgängligt "live"`,
     },
 
     customize_content: {


### PR DESCRIPTION
Blargmode doesn't maintain his theme anymore, and it's completely broken
now that SweClockers have launched their new design (#124).

We only support Soitora's theme now.