### PR TITLE
Fix editing tools preferences formatting

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@ const i = (x: string) => PREFIX_ID + x;
 const c = (x: string) => PREFIX_CLASS + x;
 
 export const ID_STYLE_ELEMENT = i("main-style-element");
-export const EDITING_TOOLS_HEIGHT = "140px"; // to prevent jumping in preferences interface
+export const EDITING_TOOLS_HEIGHT = "200px"; // to prevent jumping in preferences interface
 
 // distance between article and left side of improved corrections dialog
 export const CORRECTIONS_DIALOG_OFFSET_PX = 20;

--- a/src/operations/preferences-menu.tsx
+++ b/src/operations/preferences-menu.tsx
@@ -3,13 +3,14 @@ import { h, render } from "preact";
 import { PreferencesForm } from "~src/preferences-menu";
 import * as SITE from "~src/site";
 import * as T from "~src/text";
+import { yyyymmdd } from "~src/utilities";
 
 export default () => {
     document.title = T.preferences.title;
     document.documentElement.appendChild((() => {
         const link = document.createElement("link");
         link.rel = "stylesheet";
-        link.href = SITE.STYLESHEET_URL;
+        link.href = SITE.STYLESHEET_URL(yyyymmdd(new Date()));
         return link;
     })());
     render(<PreferencesForm />, document.body);

--- a/src/site.ts
+++ b/src/site.ts
@@ -6,7 +6,7 @@ export const NAME = U.sitename;
 export const HOSTNAME = U.hostname;
 export const HOSTNAME_MOBILE = `m.` + HOSTNAME;
 
-export const STYLESHEET_URL = "/css/combine.min.css";
+export const STYLESHEET_URL = (yyyymmdd: string) => `/css/combine.min.sass.css?v=${yyyymmdd}`;
 
 export const BANNER_HEIGHT_TOP = `${121}px`; // default height of top ad banner
 export const BANNER_HEIGHT_MID = `${360}px`; // default height of page ad modules

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -9,3 +9,10 @@ export function withMaybe<A, B>(ma: A | null, f: (x: A) => B): void {
         f(ma);
     }
 }
+
+export function yyyymmdd(date: Date): string {
+    const yyyy = date.getFullYear();
+    const mm = (date.getMonth() + 1 /* 0-indexed */).toString().padStart(2, "0");
+    const dd = date.getDate().toString().padStart(2, "0");
+    return yyyy + mm + dd;
+}


### PR DESCRIPTION
Reported in #146.

This fix brings back the default SweClockers stylesheet in the
preferences menu, which apparently causes other problems. I'll address
those in a different PR.