### PR TITLE
Simplify unsupported preference error handling

### DIFF
--- a/src/preferences-menu.tsx
+++ b/src/preferences-menu.tsx
@@ -160,9 +160,7 @@ function InputElement<T extends AllowedTypes>(generators: Generators, p: Prefere
     if (is(ListPreference)(p) && p === P.interests._.uninteresting_subforums) {
         return <Interests p={p} />;
     }
-    const msg = `Unsupported preference: ${p}`;
-    log.error(msg);
-    return <mark>{msg}</mark>;
+    throw new Error(`Unsupported preference: ${p}`);
 }
 
 function Generator_Boolean(p: BooleanPreference): GeneratorOutput {

--- a/src/stylesheets/preferences.scss
+++ b/src/stylesheets/preferences.scss
@@ -35,16 +35,6 @@ form##{getGlobal("CONFIG.USERSCRIPT_ID")} {
         input + label::after, select + label::after, textarea + label::after {
             content: unset;
         }
-
-        // Unsupported preference notice
-        mark {
-            border: 3px solid #D00;
-            color: #D00;
-            display: inline-block;
-            font: bold 1em monospace;
-            margin: 2px;
-            padding: 1em;
-        }
     }
 
     .#{getGlobal("SITE.CLASS.fieldset")} {


### PR DESCRIPTION
Instead of showing an obvious error message to the user in the middle of
the preferences menu, we'll fail altogether.

The rationale for the old solution was that we might forget to check
that a new preference was supported by the GUI, so we might merge a
change that would completely break the preferences GUI for users without
even noticing. However, I've found a way to prevent this through tests,
which will be implemented in a separate PR.