### PR TITLE
Patch bug where proofreading messes up headings

### DIFF
--- a/src/operations.ts
+++ b/src/operations.ts
@@ -240,7 +240,12 @@ const OPERATIONS: readonly Operation<any>[] = [
     operation({
         description: "perform proofreading processing",
         condition: () => isReadingEditorialContent || (isInEditMode && Preferences.get(P.advanced._.proofread_forum_posts)),
-        action: Proofreading.performProcessing,
+        action: Proofreading.performProcessing(
+            // Hotfix for #152.
+            isReadingEditorialContent
+                ? [ SELECTOR.bbParagraph ]
+                : [ SELECTOR.bbParagraph, "h1", "h2", "h3" ]
+        ),
         deferUntil: DOMCONTENTLOADED,
     }),
     operation({

--- a/src/operations/proofreading.ts
+++ b/src/operations/proofreading.ts
@@ -16,8 +16,8 @@ const ELEMENTS_TO_GO_OUTSIDE = [
     "sup",
 ].map(x => x.toUpperCase()); // because .tagName is upper case
 
-export function performProcessing() {
-    const selector = [ SELECTOR.bbParagraph, "h1", "h2", "h3" ].join(", ");
+export const performProcessing = (selectors: readonly string[]) => () => {
+    const selector = selectors.join(", ");
     for (const n of document.querySelectorAll(selector)) {
         processNode(n);
     }
@@ -39,7 +39,7 @@ export function performProcessing() {
             }, 10);
         });
     }
-}
+};
 
 export const enum Options {
     ALWAYS,


### PR DESCRIPTION
This is a hotfix for #152.

Headings were incorrectly made uppercase by our proofreading processing
in combination with SweClockers' stylesheet.

I think we should aim for a better solution once we've incorporated `better-sweclockers-lib` into Better SweClockers.