### PR TITLE
Remove dark theme backup server option

### DIFF
--- a/src/dark-theme.ts
+++ b/src/dark-theme.ts
@@ -1,6 +1,5 @@
 export const AUTHOR = "Soitora" as const;
 export const URL = {
-    canonical: "https://soitora.com/SweClockers-Dark/sweclockers-dark.min.css",
-    backup: `https://simonalling.se/userscripts/better-sweclockers/dark-theme-${AUTHOR.toLowerCase()}.css`,
+    stylesheet: "https://soitora.com/SweClockers-Dark/sweclockers-dark.min.css",
     info: "/forum/trad/1515628",
 } as const;

--- a/src/operations/dark-theme.tsx
+++ b/src/operations/dark-theme.tsx
@@ -44,8 +44,7 @@ export function manage(): void {
 }
 
 function apply(newState: boolean): void {
-    const urlWithoutCacheInvalidation = Preferences.get(P.dark_theme._.use_backup) ? darkTheme.URL.backup : darkTheme.URL.canonical;
-    const url = withCacheInvalidation(urlWithoutCacheInvalidation, new Date());
+    const url = withCacheInvalidation(darkTheme.URL.stylesheet, new Date());
     if (newState) {
         if (isNull(document.getElementById(CONFIG.ID.darkThemeStylesheet))) {
             // Not document.head because it can be null, e.g. in a background tab in Firefox:

--- a/src/preferences/dark-theme.ts
+++ b/src/preferences/dark-theme.ts
@@ -73,10 +73,4 @@ export default {
         max: 600,
         extras: { suffix: T.general.seconds },
     }),
-    use_backup: new BooleanPreference({
-        key: "dark_theme_use_backup",
-        default: false,
-        label: T.preferences.dark_theme.use_backup,
-        description: T.preferences.dark_theme.use_backup_description,
-    }),
 } as const;

--- a/src/text.ts
+++ b/src/text.ts
@@ -178,8 +178,6 @@ export const preferences = {
         and: `och`,
         interval: `Uppdateringsintervall`,
         interval_description: `Hur ofta ${CONFIG.USERSCRIPT_NAME} ska kolla vad klockan är`,
-        use_backup: `Använd Allings server`,
-        use_backup_description: `Workaround om det mörka temat inte är tillgängligt "live"`,
     },
 
     customize_content: {


### PR DESCRIPTION
It's unlikely to be needed now that Soitora hosts the dark theme on
GitHub, and I haven't been updating/maintaining the backup server
properly anyway.