### PR TITLE
Patch quote signature buttons

### DIFF
--- a/src/operations/quote-signature-buttons.tsx
+++ b/src/operations/quote-signature-buttons.tsx
@@ -1,3 +1,4 @@
+import classnames from "classnames";
 import { h, render } from "preact";
 import { isNull, only } from "ts-type-guards";
 import { log } from "userscripter";
@@ -64,11 +65,10 @@ function form(props: {
             ]}
             <button
                 type="submit"
-                class={SITE.CLASS.button}
+                class={classnames(SITE.CLASS.button, noSignature ? SITE.CLASS.disabled : null)}
                 title={noSignature ? T.general.quote_signature_tooltip_no_signature : T.general.quote_signature_tooltip}
                 disabled={noSignature}
             >
-                <span class={SITE.CLASS.icon}></span>
                 <span class={SITE.CLASS.label}>{T.general.quote_signature_label}</span>
             </button>
         </form>

--- a/src/operations/quote-signature-buttons.tsx
+++ b/src/operations/quote-signature-buttons.tsx
@@ -32,7 +32,7 @@ export default (e: { quickReplyForm: HTMLElement }) => {
             render(form({
                 signature,
                 postID,
-                author: authorLink.textContent || "",
+                author: (authorLink.textContent || "").trim(),
                 userMessage,
                 replyURL: (e.quickReplyForm as HTMLFormElement).getAttribute("action") || "",
                 csrf,

--- a/src/site.ts
+++ b/src/site.ts
@@ -46,6 +46,7 @@ export const CLASS = {
     link: "link",
     icon: "icon",
     label: "label",
+    disabled: "is-disabled",
     inner: "inner",
     colorOrange: "color-orange",
     menuItem: "menuItem",

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -32,7 +32,7 @@ textarea.#{getGlobal("CONFIG.CLASS.codeInput")}, .#{getGlobal("CONFIG.CLASS.code
 }
 
 .#{getGlobal("SITE.CLASS.forumPost")} .#{getGlobal("SITE.CLASS.forumPostControls")} .#{getGlobal("CONFIG.CLASS.quoteSignatureButton")} {
-    margin-left: -50px; // to prevent horizontal overflow e.g. on a tablet
+    float: right;
 }
 
 .#{getGlobal("CONFIG.CLASS.linkToTop")} {


### PR DESCRIPTION
They were broken by SweClockers' new, responsive design (#124).

  * The button obscured the report button.
  * The post author name contained extraneous whitespace.

Resolves #171.