### PR TITLE
Improve preferences meta text naming

### DIFF
--- a/src/operations/preferences-menu.tsx
+++ b/src/operations/preferences-menu.tsx
@@ -6,7 +6,7 @@ import * as T from "~src/text";
 import { yyyymmdd } from "~src/utilities";
 
 export default () => {
-    document.title = T.preferences.title;
+    document.title = T.preferences._.title;
     document.documentElement.appendChild((() => {
         const link = document.createElement("link");
         link.rel = "stylesheet";

--- a/src/operations/preferences-shortcut.tsx
+++ b/src/operations/preferences-shortcut.tsx
@@ -13,12 +13,12 @@ export default (e: {
         // Derived from the other links in the notifications bar.
         <a
             href={CONFIG.PATH.PREFERENCES.link(SITE.PATH.SETTINGS.link)}
-            title={T.preferences.title}
+            title={T.preferences._.title}
             class="margin-medium-right"
         >
             <svg class="icon" dangerouslySetInnerHTML={{ __html: SITE.ICONS.settings }} />
             <span class="margin-small-left display-none display-l-inherit">
-                {T.preferences.shortcut_label}
+                {T.preferences._.shortcut_label}
             </span>
         </a>
     ), e.notificationsBar, placeholder);

--- a/src/preferences-menu.tsx
+++ b/src/preferences-menu.tsx
@@ -66,16 +66,16 @@ export class PreferencesForm extends Component {
         return (
             <form id={CONFIG.USERSCRIPT_ID}>
                 <header>
-                    <a href={document.referrer || "/"} title={T.preferences.back_to_sweclockers}>
+                    <a href={document.referrer || "/"} title={T.preferences._.back_to_sweclockers}>
                         <img src={CONFIG.URL_LOGO} alt={CONFIG.USERSCRIPT_NAME} />
                     </a>
                 </header>
                 {Entries(GENERATORS, P)}
                 <footer>
-                    <p>{T.preferences.save_notice}</p>
+                    <p>{T.preferences._.save_notice}</p>
                     <p>
-                        <a href={document.referrer || "/"} title={T.preferences.back_to_sweclockers}>
-                            {T.preferences.back_to_sweclockers}
+                        <a href={document.referrer || "/"} title={T.preferences._.back_to_sweclockers}>
+                            {T.preferences._.back_to_sweclockers}
                         </a>
                     </p>
                 </footer>
@@ -174,7 +174,7 @@ function Generator_Boolean(p: BooleanPreference): GeneratorOutput {
 
 function Generator_String(p: StringPreference): GeneratorOutput {
     return (
-        p.label === T.preferences.NO_LABEL ? [] : [ <PreferenceLabel preference={p} /> ]
+        p.label === T.preferences._.NO_LABEL ? [] : [ <PreferenceLabel preference={p} /> ]
     ).concat([
         (p.multiline
             ?
@@ -422,7 +422,7 @@ class Interests extends Component<{ p: ListPreference<number> }, InterestsState>
                     </ul>
                 );
             case "failure":
-                return T.preferences.failed_to_fetch_categories;
+                return T.preferences._.failed_to_fetch_categories;
         }
     }
 }

--- a/src/preferences/advanced.ts
+++ b/src/preferences/advanced.ts
@@ -94,7 +94,7 @@ export default {
     custom_css_code: new StringPreference({
         key: "custom_css_code",
         default: "",
-        label: T.preferences.NO_LABEL,
+        label: T.preferences._.NO_LABEL,
         description: T.preferences.advanced.custom_css_enable_description,
         multiline: true,
         extras: { class: CONFIG.CLASS.codeInput },

--- a/src/preferences/dark-theme.ts
+++ b/src/preferences/dark-theme.ts
@@ -28,13 +28,13 @@ export default {
     active: new BooleanPreference({
         key: "dark_theme_active",
         default: false,
-        label: T.preferences.NO_LABEL,
+        label: T.preferences._.NO_LABEL,
         extras: { implicit: true },
     }),
     last_autoset_state: new BooleanPreference({
         key: "dark_theme_last_autoset_state",
         default: false,
-        label: T.preferences.NO_LABEL,
+        label: T.preferences._.NO_LABEL,
         extras: { implicit: true },
     }),
     show_toggle: new BooleanPreference({

--- a/src/preferences/edit-mode.ts
+++ b/src/preferences/edit-mode.ts
@@ -42,7 +42,7 @@ export default {
         key: "textarea_size",
         default: DEFAULT_TEXTAREA_SIZE,
         min: 0, max: Number.MAX_VALUE,
-        label: T.preferences.NO_LABEL,
+        label: T.preferences._.NO_LABEL,
         extras: { implicit: true },
     }),
     textarea_size_toggle,
@@ -74,8 +74,8 @@ export default {
     monospace_font_in_quick_reply_form: new BooleanPreference({
         key: "monospace_font_in_quick_reply_form",
         default: false,
-        label: T.preferences.in_quick_reply_form,
-        description: T.preferences.in_quick_reply_form_description,
+        label: T.preferences._.in_quick_reply_form,
+        description: T.preferences._.in_quick_reply_form_description,
         extras: { class: CONFIG.CLASS.inlinePreference },
     }),
     improved_builtin_editing_tools: new BooleanPreference({
@@ -106,8 +106,8 @@ export default {
     keyboard_shortcuts_in_quick_reply: new BooleanPreference({
         key: "keyboard_shortcuts_in_quick_reply",
         default: false,
-        label: T.preferences.in_quick_reply_form,
-        description: T.preferences.in_quick_reply_form_description,
+        label: T.preferences._.in_quick_reply_form,
+        description: T.preferences._.in_quick_reply_form_description,
         extras: { class: CONFIG.CLASS.inlinePreference },
     }),
     insert_tab: new BooleanPreference({
@@ -120,7 +120,7 @@ export default {
     insert_tab_content: new MultichoicePreference({
         key: "insert_tab_content",
         default: TAB,
-        label: T.preferences.NO_LABEL,
+        label: T.preferences._.NO_LABEL,
         options: [
             {
                 value: TAB,

--- a/src/preferences/editing-tools.ts
+++ b/src/preferences/editing-tools.ts
@@ -45,8 +45,8 @@ export default {
     in_quick_reply_form: new BooleanPreference({
         key: "editing_tools_in_quick_reply_form",
         default: true,
-        label: T.preferences.in_quick_reply_form,
-        description: T.preferences.in_quick_reply_form_description,
+        label: T.preferences._.in_quick_reply_form,
+        description: T.preferences._.in_quick_reply_form_description,
         extras: { class: CONFIG.CLASS.inlinePreference },
     }),
     position: new MultichoicePreference({

--- a/src/preferences/general.ts
+++ b/src/preferences/general.ts
@@ -48,13 +48,13 @@ export default {
     location_region: new IntegerPreference({
         key: "location_region",
         default: 0, // "Välj region:"
-        label: T.preferences.NO_LABEL,
+        label: T.preferences._.NO_LABEL,
         extras: { implicit: true },
     }),
     location_city: new StringPreference({
         key: "location_city",
         default: "",
-        label: T.preferences.NO_LABEL,
+        label: T.preferences._.NO_LABEL,
         multiline: false,
         extras: { implicit: true },
     }),

--- a/src/preferences/interests.ts
+++ b/src/preferences/interests.ts
@@ -5,7 +5,7 @@ import * as T from "~src/text";
 export default {
     uninteresting_subforums: new ListPreference<number>({
         key: "interests_uninteresting_subforums",
-        label: T.preferences.NO_LABEL,
+        label: T.preferences._.NO_LABEL,
         default: [],
     }),
 } as const;

--- a/src/preferences/keyboard.ts
+++ b/src/preferences/keyboard.ts
@@ -10,7 +10,7 @@ export type ShortcutEntry = Readonly<{
 
 export default new ListPreference<ShortcutEntry>({
     key: "keyboard",
-    label: T.preferences.NO_LABEL,
+    label: T.preferences._.NO_LABEL,
     default: [
         { shortcut: "mod+s", action: Action.SUBMIT },
         { shortcut: "mod+p", action: Action.PREVIEW },

--- a/src/text.ts
+++ b/src/text.ts
@@ -61,14 +61,16 @@ export const general = {
 } as const;
 
 export const preferences = {
-    NO_LABEL: ``,
-    shortcut_label: `BSC`,
-    title: `Inställningar för Better SweClockers`,
-    back_to_sweclockers: `Tillbaka till ${SITE.NAME}`,
-    save_notice: `Inställningarna sparas automatiskt, men endast lokalt på den här enheten.`,
-    failed_to_fetch_categories: `Kunde inte hämta forumkategorier.`,
-    in_quick_reply_form: `i formuläret <em>Snabbsvar</em>`,
-    in_quick_reply_form_description: `Längst ner i trådar`,
+    _: {
+        NO_LABEL: ``,
+        shortcut_label: `BSC`,
+        title: `Inställningar för Better SweClockers`,
+        back_to_sweclockers: `Tillbaka till ${SITE.NAME}`,
+        save_notice: `Inställningarna sparas automatiskt, men endast lokalt på den här enheten.`,
+        failed_to_fetch_categories: `Kunde inte hämta forumkategorier.`,
+        in_quick_reply_form: `i formuläret <em>Snabbsvar</em>`,
+        in_quick_reply_form_description: `Längst ner i trådar`,
+    },
 
     general: {
         label: `Allmänt`,


### PR DESCRIPTION
This clarifies the fact that the keys representing meta text values are
separate from those representing categories ("general", "advanced" etc).