### PR TITLE
Use Europe/Stockholm time zone in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,8 @@ jobs:
     name: CI Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/set-timezone-action@v1.0
+      - name: Set time zone
+        uses: szenius/set-timezone@v1.0
         with:
           timezoneLinux: "Europe/Stockholm"
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ jobs:
     name: CI Build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/set-timezone-action@v1.0
+        with:
+          timezoneLinux: "Europe/Stockholm"
       - uses: actions/checkout@v1
       - name: Setup Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -11,6 +11,9 @@ jobs:
     name: Validation Build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/set-timezone-action@v1.0
+        with:
+          timezoneLinux: "Europe/Stockholm"
       - uses: actions/checkout@v1
       - name: Setup Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -11,7 +11,8 @@ jobs:
     name: Validation Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/set-timezone-action@v1.0
+      - name: Set time zone
+        uses: szenius/set-timezone@v1.0
         with:
           timezoneLinux: "Europe/Stockholm"
       - uses: actions/checkout@v1


### PR DESCRIPTION
Before this PR, the version number generated in CI was somewhat
confusingly off by one or two hours (depending on DST) with respect to
Sweden time. SweClockers is obviously de facto Sweden-centered, so it
makes sense to use Sweden time for the version number.