### PR TITLE
Incorporate better-sweclockers-lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,18 +2,6 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
-    "@alling/better-sweclockers-lib": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@alling/better-sweclockers-lib/-/better-sweclockers-lib-1.1.6.tgz",
-      "integrity": "sha512-1bx5cO7TiAD3cJC93De9YwTA0YaP0zUAgT6mxT5u0R7HKU4m3SxCaUDUkb/8mM5PdTj/5MkofRfRfWIkD+MD+w==",
-      "requires": {
-        "@alling/sweclockers-writing-rules": "^3.0.2",
-        "@typed/compose": "^1.0.0",
-        "bbcode-tags": "^1.0.0",
-        "highlight-mistakes": "^1.0.0",
-        "ts-type-guards": "^0.6.1"
-      }
-    },
     "@alling/sweclockers-writing-rules": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@alling/sweclockers-writing-rules/-/sweclockers-writing-rules-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     }
   },
   "dependencies": {
-    "@alling/better-sweclockers-lib": "^1.1.6",
+    "@alling/sweclockers-writing-rules": "^3.0.2",
     "@babel/preset-env": "^7.12.1",
     "@typed/compose": "^1.0.0",
     "@types/app-root-path": "^1.2.4",
@@ -35,6 +35,7 @@
     "eslint": "^7.4.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-react": "^7.20.3",
+    "highlight-mistakes": "^1.0.0",
     "husky": "^3.1.0",
     "jest": "^26.1.0",
     "jest-function": "^1.0.1",

--- a/src/lib/proofreading/classes.ts
+++ b/src/lib/proofreading/classes.ts
@@ -1,0 +1,8 @@
+// This file cannot contain Webpack-resolved imports (e.g. "~src/foo").
+
+export default {
+    proofread: "proofread",
+    any: "any",
+    mistake: "mistake",
+    verified: "verified",
+} as const;

--- a/src/lib/proofreading/index.ts
+++ b/src/lib/proofreading/index.ts
@@ -1,0 +1,66 @@
+import { RULES, RULES_SUP, PATTERN_DOPPELGANGERS } from "@alling/sweclockers-writing-rules";
+import { compose } from "@typed/compose";
+import { proofreadWith, highlightWith } from "highlight-mistakes";
+
+import C from "./classes";
+
+type StringTransformer = (s: string) => string;
+
+export function processNodeWith(f: StringTransformer, sup: StringTransformer): (node: Node) => void {
+    return node => {
+        if (node.nodeType === Node.TEXT_NODE) {
+            const span = document.createElement("span");
+            span.innerHTML = f(escapeHTML(node.textContent || ""));
+            (node.parentNode as Node).replaceChild(span, node);
+        } else if (node.nodeType === Node.ELEMENT_NODE) {
+            if (node.nodeName === "SUP") {
+                (node as HTMLElement).innerHTML = sup(node.textContent || "");
+            } else {
+                Array.from(node.childNodes).forEach(processNodeWith(f, sup));
+            }
+        }
+    };
+}
+
+export function markWith(className: string): (info: string | null) => StringTransformer {
+    const isMistake = className === C.mistake;
+    return info => s => [
+        `<span class="${C.proofread} ${className}"`,
+        (isMistake && info !== null ? ` title="Förslag: ${info}"` : ""),
+        `>${s}</span>`,
+    ].join("");
+}
+
+export const processSup = proofreadWith({
+    rules: RULES_SUP,
+    markMistake: markWith(C.mistake),
+    markVerified: markWith(C.verified),
+});
+
+export const processText = compose(
+    highlightWith({
+        pattern: PATTERN_DOPPELGANGERS,
+        mark: markWith(C.any)(null),
+    }),
+    proofreadWith({
+        rules: RULES,
+        markMistake: markWith(C.mistake),
+        markVerified: markWith(C.verified),
+    }),
+);
+
+export const processNode = processNodeWith(processText, processSup);
+
+function replacer(found: `&` | `<` | `>` | `"` | `'`): string {
+    switch (found) {
+        case `&`: return "&amp;";
+        case `<`: return "&lt;";
+        case `>`: return "&gt;";
+        case `"`: return "&quot;";
+        case `'`: return "&#039;"; // https://stackoverflow.com/questions/2083754
+    }
+}
+
+function escapeHTML(html: string): string {
+    return html.replace(/[&<>"']/g, replacer as (substring: string) => string);
+}

--- a/src/lib/proofreading/style.scss
+++ b/src/lib/proofreading/style.scss
@@ -1,0 +1,32 @@
+.#{getGlobal("PROOFREADING.proofread")} {
+    white-space: pre;
+}
+
+$invisibleBorder: 4px; // to make it easier to hover
+.#{getGlobal("PROOFREADING.mistake")} {
+    &, .#{getGlobal("PROOFREADING.any")} {
+        background-color: rgba(240, 70, 0, 1);
+        background-clip: content-box;
+        border: $invisibleBorder solid rgba(240, 70, 0, 0.1);
+        border-radius: 2px;
+        cursor: help;
+        margin: -$invisibleBorder;
+        position: relative; // so it gets in front of the text around it
+        transition: border-color 250ms 100ms
+    }
+
+    &:hover, .#{getGlobal("PROOFREADING.any")}:hover {
+        border-color: rgba(240, 70, 0, 0.6);
+        transition-delay: 0ms;
+    }
+}
+
+.#{getGlobal("PROOFREADING.verified")} {
+    &, .#{getGlobal("PROOFREADING.any")} {
+        background-color: rgb(85, 220, 0);
+    }
+}
+
+.#{getGlobal("PROOFREADING.any")} {
+    background-color: rgb(85, 130, 250);
+}

--- a/src/lib/textarea.ts
+++ b/src/lib/textarea.ts
@@ -1,0 +1,102 @@
+import * as BB from "bbcode-tags";
+import * as textFieldEdit from "text-field-edit";
+import { isNumber } from "ts-type-guards";
+
+type InsertionResult = Readonly<{
+    textareaContent: string,
+    startOfInserted: number,
+    endOfInserted: number,
+}>
+
+type Insertion = Readonly<{
+    string: string,
+    replace: boolean,
+}>
+
+type WrapAction = Readonly<{
+    cursor: CursorBehavior,
+    before: string,
+    after: string,
+}>
+
+type TagWrapAction = Readonly<{
+    tag: string,
+    parameterized: boolean,
+    block: boolean,
+}>
+
+export type Action = (textarea: HTMLTextAreaElement, undoSupport: boolean) => void
+
+export type CursorBehavior = number | "KEEP_SELECTION"
+
+export function wrapIn(textarea: HTMLTextAreaElement, w: WrapAction): void {
+    const replacement = w.before + selectedTextIn(textarea) + w.after;
+    // Since wrapping doesn't delete any text, undo support is not relevant and replacing is always safe.
+    const insertionResult = insertPure(textarea, { string: replacement, replace: true });
+    // We must use textFieldEdit.wrapSelection, because if we use insertPure + textFieldEdit.set, the entire textarea content gets selected when the user issues an undo command.
+    textFieldEdit.wrapSelection(textarea, w.before, w.after);
+    // Since we use the insertion result here, it must represent the same modification of the textarea content as textFieldEdit.wrapSelection.
+    if (isNumber(w.cursor)) {
+        placeCursorIn(textarea, insertionResult.startOfInserted + w.cursor);
+    } else {
+        selectRangeIn(textarea, insertionResult.startOfInserted + w.before.length, insertionResult.endOfInserted - w.after.length);
+    }
+}
+
+export function wrap_verbatim(w: WrapAction): Action {
+    return (textarea, _) => wrapIn(textarea, w);
+}
+
+export function wrap_tag(w: TagWrapAction): Action {
+    const spacing = w.block ? "\n" : "";
+    return wrap_verbatim({
+        before: BB.start(w.tag, w.parameterized ? "" : undefined) + spacing,
+        after: spacing + BB.end(w.tag),
+        cursor: (
+            w.parameterized
+                ? 1 + w.tag.length + 2 // 1 for '[', 2 for '="'
+                : "KEEP_SELECTION"
+        ),
+    });
+}
+
+export function selectedTextIn(textarea: HTMLTextAreaElement): string {
+    return textarea.value.substring(textarea.selectionStart, textarea.selectionEnd);
+}
+
+// Simple insertion. Selected text is kept in the absence of undo support to protect against accidental deletion.
+export function insert(str: string): Action {
+    return (textarea, undoSupport) => insertIn(textarea, { string: str, replace: undoSupport });
+}
+
+export function insertIn(textarea: HTMLTextAreaElement, insertion: Insertion): void {
+    // The caller of this function is fully responsible for deciding whether to replace selected text or not.
+    // textFieldEdit.insert replaces selected text, so if that's not desired, we'll first unselect it such that the insertion is done after the selection.
+    if (!insertion.replace) {
+        placeCursorIn(textarea, textarea.selectionEnd);
+    }
+    // We must use textFieldEdit.insert, because if we use insertPure + textFieldEdit.set, the entire textarea content gets selected when the user issues an undo command.
+    textFieldEdit.insert(textarea, insertion.string);
+    textarea.focus();
+}
+
+function insertPure(textarea: HTMLTextAreaElement, insertion: Insertion): InsertionResult {
+    const text = textarea.value;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const startOfInsertedText = insertion.replace ? start : end;
+    return {
+        textareaContent: text.substring(0, startOfInsertedText) + insertion.string + text.substring(end),
+        startOfInserted: startOfInsertedText,
+        endOfInserted: startOfInsertedText + insertion.string.length,
+    };
+}
+
+export function placeCursorIn(textarea: HTMLTextAreaElement, position: number): void {
+    selectRangeIn(textarea, position, position);
+}
+
+export function selectRangeIn(textarea: HTMLTextAreaElement, start: number, end: number): void {
+    textarea.setSelectionRange(start, end);
+    textarea.focus(); // Must be after setSelectionRange to avoid scrolling to the bottom of the textarea in Chrome.
+}

--- a/src/operations/proofreading.ts
+++ b/src/operations/proofreading.ts
@@ -1,6 +1,7 @@
-import { CLASS as BSCLibClass, processNode } from "@alling/better-sweclockers-lib";
 import { stylesheets } from "userscripter";
 
+import { processNode } from "~src/lib/proofreading";
+import C from "~src/lib/proofreading/classes";
 import SELECTOR from "~src/selectors";
 import * as SITE from "~src/site";
 import STYLESHEETS from "~src/stylesheets";
@@ -21,7 +22,7 @@ export const performProcessing = (selectors: readonly string[]) => () => {
     for (const n of document.querySelectorAll(selector)) {
         processNode(n);
     }
-    for (const mistake of document.querySelectorAll("."+BSCLibClass.MARK.mistake)) {
+    for (const mistake of document.querySelectorAll("."+C.mistake)) {
         mistake.addEventListener("click", () => {
             if (getProofDialogTextarea() === null) {
                 withMaybe(document.getElementById(SITE.ID.correctionsLink), correctionsLink => {

--- a/src/stylesheets.ts
+++ b/src/stylesheets.ts
@@ -1,10 +1,10 @@
-import { STYLE_PROOFREADING } from "@alling/better-sweclockers-lib";
 import * as ms from "milliseconds";
 import { ALWAYS } from "userscripter/lib/environment";
 import { Stylesheets, stylesheet } from "userscripter/lib/stylesheets";
 
 import * as CONFIG from "~src/config";
 import { isInEditMode, isOnBSCPreferencesPage, isOnSweclockersSettingsPage, isReadingThread } from "~src/environment";
+import STYLE_PROOFREADING from "~src/lib/proofreading/style.scss";
 import { P, Preferences } from "~src/preferences";
 import SELECTOR from "~src/selectors";
 import * as SITE from "~src/site";

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -40,7 +40,6 @@ textarea.#{getGlobal("CONFIG.CLASS.codeInput")}, .#{getGlobal("CONFIG.CLASS.code
     }
 }
 
-// Selector must be kept in sync with @alling/better-sweclockers-lib:
-.mistake {
+.#{getGlobal("PROOFREADING.mistake")} {
     border-color: rgba(240, 70, 0, 0.6);
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -10,6 +10,7 @@ import { RawSource } from "webpack-sources";
 
 import METADATA, { versionBasedOnDate } from "./metadata";
 import * as CONFIG from "./src/config";
+import PROOFREADING from "./src/lib/proofreading/classes";
 import * as SITE from "./src/site";
 import * as T from "./src/text";
 import U from "./src/userscript";
@@ -24,7 +25,7 @@ const w = createWebpackConfig({
             now: now,
         }),
         hostedAt: U.hostedAt,
-        sassVariables: { CONFIG, SITE, T },
+        sassVariables: { CONFIG, PROOFREADING, SITE, T },
     },
     metadata: METADATA,
     metadataSchema: DEFAULT_METADATA_SCHEMA,


### PR DESCRIPTION
The plan is to make BSC a package exposing the same API.

The textarea tests are omitted because document.execCommand and
document.activeElement are not defined in Node.