### PR TITLE
Fix proofreading mistake highlighting

### DIFF
--- a/src/lib/proofreading/style.scss
+++ b/src/lib/proofreading/style.scss
@@ -6,7 +6,7 @@ $invisibleBorder: 4px; // to make it easier to hover
 .#{getGlobal("PROOFREADING.mistake")} {
     &, .#{getGlobal("PROOFREADING.any")} {
         background-color: rgba(240, 70, 0, 1);
-        background-clip: content-box;
+        background-clip: padding-box;
         border: $invisibleBorder solid rgba(240, 70, 0, 0.1);
         border-radius: 2px;
         cursor: help;


### PR DESCRIPTION
The entire box would be opaque, including the border.