### PR TITLE
Improve quote signature button tooltips

### DIFF
--- a/src/operations/quote-signature-buttons.tsx
+++ b/src/operations/quote-signature-buttons.tsx
@@ -66,7 +66,7 @@ function form(props: {
             <button
                 type="submit"
                 class={classnames(SITE.CLASS.button, noSignature ? SITE.CLASS.disabled : null)}
-                title={noSignature ? T.general.quote_signature_tooltip_no_signature : T.general.quote_signature_tooltip}
+                title={noSignature ? T.general.quote_signature_tooltip_no_signature(props.author) : T.general.quote_signature_tooltip}
                 disabled={noSignature}
             >
                 <span class={SITE.CLASS.label}>{T.general.quote_signature_label}</span>

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -37,6 +37,10 @@ textarea.#{getGlobal("CONFIG.CLASS.codeInput")}, .#{getGlobal("CONFIG.CLASS.code
 
     > button {
         margin-right: 0; // Otherwise the margins are stacked.
+
+        &[disabled] {
+            pointer-events: unset;
+        }
     }
 }
 

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -39,7 +39,7 @@ textarea.#{getGlobal("CONFIG.CLASS.codeInput")}, .#{getGlobal("CONFIG.CLASS.code
         margin-right: 0; // Otherwise the margins are stacked.
 
         &[disabled] {
-            pointer-events: unset;
+            pointer-events: unset; // Makes the tooltip show up on disabled buttons in Chrome.
         }
     }
 }

--- a/src/text.ts
+++ b/src/text.ts
@@ -44,7 +44,7 @@ export const general = {
     generic_lines_confirm: (n: number) => `${n} markerad${n > 1 ? "e rader" : " rad"} kommer formateras. Är du säker?`,
     quote_signature_label: `Citera sign.`,
     quote_signature_tooltip: `Citera endast signatur`,
-    quote_signature_tooltip_no_signature: `Signatur saknas`,
+    quote_signature_tooltip_no_signature: (author: string) => `${author} har ingen signatur`,
     mention_everyone_label,
     mention_everyone_tooltip: `Nämn alla tråddeltagare på den här sidan i ett nytt inlägg`,
     uninteresting_subforum: (subforumName: string) => `Du har markerat kategorin ${subforumName} som ointressant.`,


### PR DESCRIPTION
The CSS change makes the tooltip show up on disabled buttons in Chrome.