### PR TITLE
Add developer mode

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,7 @@ export const WRAPPER_WIDTH_EXTRA_ALLOWED_SHRINK_AMOUNT = 60;
 export const NBSP = "\u00A0";
 
 export const ID = {
+    developerTools: i("developer-tools"),
     document: i("document"),
     preferenceIdPrefix: i("preference-"),
     editingTools: i("editing-tools"),
@@ -43,6 +44,11 @@ export const ID = {
 
 export const CLASS = {
     mousetrap: "mousetrap",
+    developerTools: {
+        // I couldn't use "error", because Soitora's dark theme would give such elements a weird red background.
+        error: i("error"),
+        warning: i("warning"),
+    },
     disabled: c("disabled"),
     editingTools: c("editing-tools"),
     iconButton: c("icon-button"),
@@ -90,6 +96,7 @@ export const KEY = {
     autosaved_draft: i("autosaved_draft"),
     caret_position: i("caret_position_in_textarea"),
     last_time_user_tried_to_submit: i("last_time_user_tried_to_submit"),
+    developer_tools_open: i("developer_tools_open"),
     draft_mode: i("draft_mode"),
 } as const;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,8 @@ import { environment, errors, log, userscripter } from "userscripter";
 import * as CONFIG from "~src/config";
 import OPERATIONS from "~src/operations";
 import * as DarkTheme from "~src/operations/dark-theme";
+import * as Developer from "~src/operations/developer-mode";
+import { P, Preferences } from "~src/preferences";
 import * as SITE from "~src/site";
 import STYLESHEETS from "~src/stylesheets";
 import U from "~src/userscript";
@@ -15,6 +17,12 @@ const describeFailure = errors.failureDescriber({
 });
 
 DarkTheme.manage(); // In an effort to avoid a bright flash on page load (issue #62), we do this as early as possible.
+
+log.setLogger(
+    Preferences.get(P.advanced._.developer_mode)
+        ? Developer.logger(console, document.documentElement.appendChild(document.createElement("div")))
+        : console
+);
 
 userscripter.run({
     id: U.id,

--- a/src/operations/developer-mode.tsx
+++ b/src/operations/developer-mode.tsx
@@ -1,0 +1,94 @@
+import { Component, h, JSX, render } from "preact";
+import * as Storage from "ts-storage";
+import { log } from "userscripter";
+
+import * as CONFIG from "~src/config";
+import * as T from "~src/text";
+
+export function logger(regularLogger: log.Logger, rootNode: Element): log.Logger {
+    const initOpen = Storage.get_session(CONFIG.KEY.developer_tools_open, false).value;
+    let devTools: DevTools;
+    render(<DevTools initOpen={initOpen} ref={self => { devTools = self; }} />, rootNode);
+    return {
+        ...regularLogger,
+        error: (prefix: string, message: string) => {
+            devTools.log({ kind: "error", content: message });
+            regularLogger.error(prefix, message);
+        },
+        warn: (prefix: string, message: string) => {
+            devTools.log({ kind: "warning", content: message });
+            regularLogger.warn(prefix, message);
+        },
+    };
+}
+
+type Kind = "error" | "warning"
+
+type Message = {
+    kind: Kind
+    content: string
+}
+
+type DevToolsProps = {
+    initOpen: boolean
+}
+
+type DevToolsState = {
+    loggedMessages: readonly Message[]
+    isOpen: boolean
+}
+
+class DevTools extends Component<DevToolsProps, DevToolsState> {
+    constructor(props: DevToolsProps) {
+        super(props);
+        this.state = {
+            loggedMessages: [],
+            isOpen: props.initOpen,
+        };
+    }
+
+    public log(message: Message) {
+        this.setState(state => ({
+            loggedMessages: [ ...state.loggedMessages, message ],
+        }));
+    }
+
+    render() {
+        const loggedMessages = this.state.loggedMessages;
+        const loggedWarnings = loggedMessages.filter(msg => msg.kind === "warning");
+        const loggedErrors = loggedMessages.filter(msg => msg.kind === "error");
+        return (
+            <footer id={CONFIG.ID.developerTools} class={this.state.isOpen ? "open" : undefined} data-how-many={loggedMessages.length}>
+                <a onClick={_ => {
+                    this.setState(state => {
+                        const newOpenState = !state.isOpen;
+                        Storage.set_session(CONFIG.KEY.developer_tools_open, newOpenState);
+                        return { ...state, isOpen: newOpenState };
+                    });
+                }}>
+                    {summary(loggedErrors.length, "error")}
+                    {summary(loggedWarnings.length, "warning")}
+                </a>
+                <ol>
+                    {
+                        loggedMessages.length > 0
+                            ? loggedMessages.map(msg => <li class={CONFIG.CLASS.developerTools[msg.kind]}>{msg.content}</li>)
+                            : <li>{T.developer_mode.nothing_logged}</li>
+                    }
+                </ol>
+            </footer>
+        );
+    }
+}
+
+function summary(howMany: number, what: Kind): JSX.Element {
+    const icon = ({
+        error: "❌",
+        warning: "⚠️",
+    } as const)[what];
+    return (
+        <strong data-how-many={howMany} class={CONFIG.CLASS.developerTools[what]} title={T.developer_mode.tooltip[what](howMany)}>
+            {icon}&nbsp;&nbsp;{howMany}
+        </strong>
+    );
+}

--- a/src/preferences/advanced.ts
+++ b/src/preferences/advanced.ts
@@ -90,6 +90,12 @@ export default {
             },
         ],
     }),
+    developer_mode: new BooleanPreference({
+        key: "developer_mode",
+        default: false,
+        label: T.preferences.advanced.developer_mode,
+        description: T.preferences.advanced.developer_mode_description,
+    }),
     custom_css_enable,
     custom_css_code: new StringPreference({
         key: "custom_css_code",

--- a/src/stylesheets.ts
+++ b/src/stylesheets.ts
@@ -15,6 +15,7 @@ import adaptiveWidthCorrections from "./stylesheets/adaptive-width-corrections.s
 import adaptiveWidth from "./stylesheets/adaptive-width.scss";
 import autosaveDraft from "./stylesheets/autosave-draft.scss";
 import darkThemeTogglePreparations from "./stylesheets/dark-theme-toggle-preparations.scss";
+import developerMode from "./stylesheets/developer-mode.scss";
 import doge from "./stylesheets/doge.scss";
 import downForMaintenance from "./stylesheets/down-for-maintenance.scss";
 import editingTools from "./stylesheets/editing-tools.scss";
@@ -47,6 +48,10 @@ const STYLESHEETS = {
     main: stylesheet({
         condition: ALWAYS,
         css: main,
+    }),
+    developer_mode: stylesheet({
+        condition: () => Preferences.get(P.advanced._.developer_mode),
+        css: developerMode,
     }),
     dark_theme_toggle_preparations: stylesheet({
         condition: () => Preferences.get(P.dark_theme._.show_toggle),

--- a/src/stylesheets/developer-mode.scss
+++ b/src/stylesheets/developer-mode.scss
@@ -12,6 +12,7 @@
     display: flex;
     flex-direction: column;
     max-height: 50vh;
+    outline: 1px solid $darkgray; // for dark mode
     position: fixed;
     z-index: 9999;
 

--- a/src/stylesheets/developer-mode.scss
+++ b/src/stylesheets/developer-mode.scss
@@ -1,0 +1,96 @@
+##{getGlobal("CONFIG.ID.developerTools")} {
+    $red: #D00;
+    $yellow: #EC0;
+    $lightgray: #BBB;
+    $darkgray: #444;
+
+    $spacing: 1em;
+
+    background: black;
+    bottom: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    max-height: 50vh;
+    position: fixed;
+    z-index: 9999;
+
+    &[data-how-many="0"]:not(:hover):not(.open) {
+        opacity: 0.25;
+    }
+
+    .#{getGlobal("CONFIG.CLASS.developerTools.error")} {
+        color: $red;
+    }
+
+    .#{getGlobal("CONFIG.CLASS.developerTools.warning")} {
+        color: $yellow;
+    }
+
+    > a {
+        display: block;
+        padding: $spacing;
+
+        &:hover {
+            background-color: rgba(255, 255, 255, 0.1);
+            text-decoration: none;
+        }
+
+        strong {
+            display: inline-block;
+            width: 4em; // So content stays in place regardless of the number of logged messages.
+
+            &[data-how-many="0"] {
+                opacity: 0.25;
+            }
+
+            &:not(:last-of-type) {
+                margin-right: 1em;
+            }
+        }
+    }
+
+    ol {
+        background-color: rgba(255, 255, 255, 0.1);
+        border: 1px solid $darkgray;
+        color: $lightgray;
+        display: none; // when the dev tools are not opened
+        font-family: monospace;
+        margin: 0 $spacing $spacing $spacing;
+        overflow-y: scroll;
+        white-space: pre-wrap;
+
+        li {
+            border-color: $darkgray;
+            border-top-style: solid;
+            border-width: 1px;
+            padding: 0.5em;
+
+            &:first-of-type {
+                border-top-style: none;
+            }
+
+            $backgroundAlpha: 0.08;
+            $borderAlpha: 0.3;
+
+            &.error {
+                background-color: rgba($red, $backgroundAlpha);
+                border-color: rgba($red, $borderAlpha);
+            }
+
+            &.warning {
+                background-color: rgba($yellow, $backgroundAlpha);
+                border-color: rgba($yellow, $borderAlpha);
+            }
+        }
+    }
+
+    &.open {
+        opacity: 1;
+        width: 100vw;
+
+        ol {
+            display: block;
+        }
+    }
+}

--- a/src/text.ts
+++ b/src/text.ts
@@ -228,6 +228,8 @@ export const preferences = {
             replace_selected: `Ersätt markerad text – rekommenderas i alla webbläsare med fullgott ångra-stöd`,
             keep_selected: `Behåll markerad text – rekommenderas i <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1220696">Firefox/Gecko</a> samt på Android`, // Make sure the text matches the actual support check.
         }),
+        developer_mode: `Utvecklarläge`,
+        developer_mode_description: `Visa fel och varningar längst ner på skärmen`,
         custom_css_enable: `Infoga egen CSS:`,
         custom_css_enable_description: `Anpassa layout och utseende precis som du vill`,
         custom_css_warning: `Klistra aldrig in kod som du inte litar på!`,
@@ -308,3 +310,11 @@ export const special_characters: readonly InsertButtonDescription[] = [
     { insert: "→", tooltip: "Högerpil" },
     { insert: "™", tooltip: "Varumärke (trademark)" },
 ];
+
+export const developer_mode = {
+    nothing_logged: `Nothing has been logged.`,
+    tooltip: {
+        error: (n: number) => `${n} fel`,
+        warning: (n: number) => `${n} varning${n === 1 ? "" : "ar"}`,
+    },
+} as const;


### PR DESCRIPTION
I think it can be useful for developers/contributors to be notified
about errors when browsing SweClockers, because one doesn't usually have
the console open. This PR adds sort of a console overlay that shows all
errors and warnings logged by Better SweClockers (via Userscripter's
logging API). This is extra useful on mobile devices, which don't have a
console at all.
