### PR TITLE
Patch autosave draft (obsolete draft deletion)

### DIFF
--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -38,7 +38,7 @@ export default {
     forumLink: `.subForums td:first-child > * a[href^="/forum/"]`, // Have to be this specific because there are other random links that we don't want to match.
     forumPost: "." + SITE.CLASS.forumPost,
     forumPostAuthorLink: `a.name[itemprop="author"]`,
-    linkedForumPost: `.` + SITE.CLASS.forumPost + `.isLinked`,
+    linkedForumPost: `.` + SITE.CLASS.forumPost + `.is-linked`,
     pageNavigationAfterForumPosts: `${forumPostContainer} ~ * .pages`,
     quickReplyForm: `#quickreply form`,
     signoutButton,


### PR DESCRIPTION
It was broken by SweClockers' new, responsive design (#124).

    Could not delete any obsolete autosaved draft on this page:
    
      https://www.sweclockers.com/forum/post/17698683
    
    These dependencies were not found:
    
      post: .forum-post.isLinked