### PR TITLE
Fix replace followed threads link content jumping

### DIFF
--- a/src/stylesheets/replace-followed-threads-link.scss
+++ b/src/stylesheets/replace-followed-threads-link.scss
@@ -14,7 +14,7 @@
         }
     }
 
-    a[href="#{getGlobal("SITE.PATH.MY_POSTS")}"] {
-        margin-right: 16.5px !important; // ad-hoc solution to make it take up the same width as the followed threads link (!important necessary to override SweClockers)
+    a[href="#{getGlobal("SITE.PATH.MY_POSTS")}"] svg + span {
+        margin-right: 6.5px !important; // ad-hoc solution to make it take up the same width as the followed threads link (!important necessary to override SweClockers)
     }
 }


### PR DESCRIPTION
The icons would be pushed to the left in the narrow layout (when only
the icons are shown).