### PR TITLE
Fix pref. shortcut and dark theme toggle on mobile

### DIFF
--- a/src/operations.ts
+++ b/src/operations.ts
@@ -169,7 +169,7 @@ const OPERATIONS: readonly Operation<any>[] = [
         description: "insert preferences shortcut",
         condition: () => !isOnBSCPreferencesPage && shouldInsertPreferencesShortcut,
         dependencies: {
-            notificationsBar: ".pw-notifications",
+            notificationsBar: "." + SITE.CLASS.notifications,
         },
         action: insertPreferencesShortcut,
     }),

--- a/src/site.ts
+++ b/src/site.ts
@@ -62,6 +62,7 @@ export const CLASS = {
     bbImage: "bbImage",
     bbIns: "bbIns",
     imgControls: "imgControls",
+    notifications: "pw-notifications",
     proofDialog: "proofDialog",
     socialMediaButtons: [ `threadShare`, `greyContentShare`, `sideShare` ],
     sideBox: "sideBox",

--- a/src/stylesheets.ts
+++ b/src/stylesheets.ts
@@ -15,6 +15,7 @@ import adaptiveWidthCorrections from "./stylesheets/adaptive-width-corrections.s
 import adaptiveWidth from "./stylesheets/adaptive-width.scss";
 import autosaveDraft from "./stylesheets/autosave-draft.scss";
 import darkThemeTogglePreparations from "./stylesheets/dark-theme-toggle-preparations.scss";
+import darkThemeToggle from "./stylesheets/dark-theme-toggle.scss";
 import developerMode from "./stylesheets/developer-mode.scss";
 import doge from "./stylesheets/doge.scss";
 import downForMaintenance from "./stylesheets/down-for-maintenance.scss";
@@ -28,6 +29,7 @@ import lockHeights from "./stylesheets/lock-heights.scss";
 import main from "./stylesheets/main.scss";
 import mentionEveryone from "./stylesheets/mention-everyone.scss";
 import preferencesLink from "./stylesheets/preferences-link.scss";
+import preferencesShortcut from "./stylesheets/preferences-shortcut.scss";
 import preferences from "./stylesheets/preferences.scss";
 import replaceFollowedThreadsLink from "./stylesheets/replace-followed-threads-link.scss";
 import textareaSizeToggle from "./stylesheets/textarea-size-toggle.scss";
@@ -57,6 +59,10 @@ const STYLESHEETS = {
         css: darkThemeTogglePreparations,
         id: i("dark-theme-toggle-preparations"),
     }),
+    dark_theme_toggle: stylesheet({
+        condition: () => Preferences.get(P.dark_theme._.show_toggle),
+        css: darkThemeToggle,
+    }),
     doge: stylesheet({
         condition: ALWAYS,
         css: doge,
@@ -68,6 +74,10 @@ const STYLESHEETS = {
     preferences: stylesheet({
         condition: _ => isOnBSCPreferencesPage,
         css: preferences,
+    }),
+    preferences_shortcut: stylesheet({
+        condition: () => Preferences.get(P.general._.insert_preferences_shortcut),
+        css: preferencesShortcut,
     }),
     lock_heights: stylesheet({
         condition: () => Preferences.get(P.general._.lock_heights),

--- a/src/stylesheets/dark-theme-toggle-preparations.scss
+++ b/src/stylesheets/dark-theme-toggle-preparations.scss
@@ -1,4 +1,5 @@
-##{getGlobal("SITE.ID.menuLockToggle")}, ##{getGlobal("SITE.ID.menuLockToggleOpen")} {
+.search-field {
     // This makes space for the dark theme toggle in advance, so that it doesn't push the search field to the right when it's inserted.
-    margin-right: 40px;
+    // Having the margin on the search field and not on the menu lock toggle is necessary for it to have its intended effect in some scenarios, e.g. an iPad Pro 2017 in portrait mode. Otherwise, the search field is pushed to the right upon toggle insertion.
+    margin-left: 40px;
 }

--- a/src/stylesheets/dark-theme-toggle.scss
+++ b/src/stylesheets/dark-theme-toggle.scss
@@ -1,0 +1,6 @@
+##{getGlobal("SITE.ID.menuLockToggle")}, ##{getGlobal("SITE.ID.menuLockToggleOpen")} {
+    // This makes space for the dark theme toggle on mobile/tablet:
+    @media (max-width: 992.9px) { // SweClockers use `@media (min-width: 993px)` to switch between layouts.
+        display: none;
+    }
+}

--- a/src/stylesheets/preferences-shortcut.scss
+++ b/src/stylesheets/preferences-shortcut.scss
@@ -1,0 +1,9 @@
+.#{getGlobal("SITE.CLASS.notifications")} {
+    // This makes space for the preferences shortcut on mobile by cramming the icons together:
+    @media (max-width: 576.9px) { // SweClockers use `@media (min-width: 577px)` to switch between layouts.
+        a.margin-medium-right {
+            // Default right margin is 10px and there are 3 (vanilla) icons, so this is almost perfect.
+            margin-right: unset !important; // to override SweClockers
+        }
+    }
+}


### PR DESCRIPTION
The site was completely messed up on mobile because there was no space
for the shortcut and the toggle.

This PR makes space for the preferences shortcut by cramming the icons
together in the narrowest "phone" layout. (Doing so in the wider "phone"
layout isn't necessary and bad UX.)

As for the dark theme toggle, the menu lock toggle is now hidden to make
space for it in the "phone" and "tablet" layouts. (A more fine-grained
solution would be difficult to implement due to the fairly complex
vanilla layout in that area.)

I'm using "phone" and "tablet" to refer to the two distinct layouts
without labels in the notifications bar. There are basically three major
layouts: up to 768px ("phone"), up to 992px ("tablet") and wider (well,
"desktop"). But there is also a minor change in layout between 576px and
577px distinguishing the "narrowest 'phone' layout" mentioned above.