### PR TITLE
Remove `<!--` to enable Userscript Proxy --inline

### DIFF
--- a/src/icons/quote.svg
+++ b/src/icons/quote.svg
@@ -2,7 +2,6 @@
     <rect x="1" y="1" width="30" height="30" stroke="#444" fill="#d7d5d1" stroke-width="2"/>
     <text x="4" y="18" style="fill: #444; font-family: Georgia, serif; font-size: 20px">”</text>
     <text       y="13" style="fill: #444; font-family: sans-serif; font-size: 4px">
-        <!-- Setting x="4" on text and x="0" on tspans doesn't work. -->
         <tspan x="4" dy="1.2em">Dumheter</tspan>
         <tspan x="4" dy="1.2em">som måste</tspan>
         <tspan x="4" dy="1.2em">besvaras.</tspan>


### PR DESCRIPTION
For security reasons, Userscript Proxy refuses to inject userscripts
inline if they contain `<!--`. Inline injection is much more helpful
(for testing on mobile devices) than the deleted comment.

SimonAlling/userscript-proxy@87c7d810f5ef52d9903b4d7a27c29e93ab37122e