### PR TITLE
Fix preferences shortcut content jumping on mobile

### DIFF
--- a/src/stylesheets/preferences-shortcut.scss
+++ b/src/stylesheets/preferences-shortcut.scss
@@ -1,9 +1,7 @@
 .#{getGlobal("SITE.CLASS.notifications")} {
-    // This makes space for the preferences shortcut on mobile by cramming the icons together:
+    // This makes space for the preferences shortcut on mobile by allowing it to overlap the logo:
     @media (max-width: 576.9px) { // SweClockers use `@media (min-width: 577px)` to switch between layouts.
-        a.margin-medium-right {
-            // Default right margin is 10px and there are 3 (vanilla) icons, so this is almost perfect.
-            margin-right: unset !important; // to override SweClockers
-        }
+        margin-left: -34px; // Default icon width and right margin are 24px and 10px, respectively.
+        z-index: 10; // so it's in front of the logo
     }
 }


### PR DESCRIPTION
The fix in #196 turned out not to work very well: The crammed margin
wouldn't be applied immediately (for me in Chrome on Android), so the
user would constantly have the notification icons moved after page load.
Not acceptable. This PR allows the preferences shortcut to overlap the
logo instead. Not perfect, but much better than before.