### PR TITLE
Fix dark theme precedence bug

### DIFF
--- a/src/operations/dark-theme.tsx
+++ b/src/operations/dark-theme.tsx
@@ -35,6 +35,11 @@ export function insertToggle(e: {
 export function manage(): void {
     if (Preferences.get(P.dark_theme._.active)) {
         apply(true);
+        document.addEventListener("DOMContentLoaded", () => {
+            // Because we insert the dark theme stylesheet as early as physically possible (to avoid a bright flash on page load; see issue #62), SweClockers' own styles will be inserted _after_ it in the DOM tree and take precedence over it, which we can't expect it to be designed for. Therefore, we move it as soon as we can.
+            // Any artifacts caused by SweClockers' own styles taking precedence will still be visible, but only very briefly instead of permanently.
+            withMaybe(document.getElementById(CONFIG.ID.darkThemeStylesheet), element => document.documentElement.appendChild(element));
+        });
     }
     if (Preferences.get(P.dark_theme._.auto)) {
         sheldon();


### PR DESCRIPTION
As pointed out in multiple posts in the forum thread, and noticed for a
long time by yours truly, we've been having problems with text fields
and other elements not being styled properly under the dark theme.

👉 https://www.sweclockers.com/forum/post/19288998
👉 https://www.sweclockers.com/forum/post/19341126
👉 https://www.sweclockers.com/forum/post/19494810

It wasn't until @jreklund pointed out that BSC added its `<style>`
elements before `<head>` that I realized the issue might be caused by
BSC and not by the dark theme itself:

> Det jag upptäckte när jag korrigerade temat var att Better SweClockers
> lägger till alla `<style>` taggar ovanför `<head>` vilket gör att
> SweClockers design inte skrivs över. Slår man av/på blir textrutorna
> korrekt, då den placerar SweClockers Dark stilmall vid `</html>`
> taggen istället.

👉 https://www.sweclockers.com/forum/post/19500553

Modulo the minor, but notable, detail that the dark theme doesn't use
any `<style>` elements, only a `<link>`, @jreklund was absolutely right.
Shoutout to him!

This is not a perfect fix. Any artifacts caused by SweClockers' own
styles taking precedence will still be visible, but only very briefly
instead of permanently.