### PR TITLE
Remove leftover YouTube button code

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -59,7 +59,6 @@ export const CLASS = {
     button_spoiler: c("button-spoiler"),
     button_code: c("button-code"),
     button_math: c("button-math"),
-    button_youtube: c("button-youtube"),
     splitQuote: c("split-quote"),
     colorPalette: c("color-palette"),
     smileys: c("smileys"),

--- a/src/site.ts
+++ b/src/site.ts
@@ -149,7 +149,6 @@ export const TAG = {
     sup: "sup",
     u: "u",
     url: "url",
-    youtube: "youtube",
 } as const;
 
 const URL_ICONS_TOOLBAR = "/gfx/toolbar2x.png";


### PR DESCRIPTION
The YouTube button itself was originally added in `a917a0b` and removed
in `f4f2714` – perhaps on accident, perhaps because there was (and still
is) a native video embedding button.