### PR TITLE
Use `math.div` instead of `/` for division in SCSS

### DIFF
--- a/src/stylesheets/improved-corrections.scss
+++ b/src/stylesheets/improved-corrections.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 ##{getGlobal("CONFIG.ID.document")} {
 
 // SweClockers has one layout for narrow viewports and one for wide viewports; in the narrow one, the rightmost ad column is not shown.
@@ -51,7 +53,7 @@ $WIDTH_WHERE_NARROW_LAYOUT_GOES_CENTERED: getGlobal("SITE.WIDTH_WHERE_NARROW_LAY
         .wndWindowArea {
             left: calc(50% + #{
                 $CORRECTIONS_DIALOG_OFFSET_PX
-                - $WRAPPER_WIDTH_NARROW_PX/2
+                - math.div($WRAPPER_WIDTH_NARROW_PX, 2)
                 + $GUTTER_SIZE_PX
                 + $ARTICLE_WIDTH_PX
             }px) !important;
@@ -63,7 +65,7 @@ $WIDTH_WHERE_NARROW_LAYOUT_GOES_CENTERED: getGlobal("SITE.WIDTH_WHERE_NARROW_LAY
         .wndWindowArea {
             left: calc(50% + #{
                 $CORRECTIONS_DIALOG_OFFSET_PX
-                - $WRAPPER_WIDTH_WIDE_PX/2
+                - math.div($WRAPPER_WIDTH_WIDE_PX, 2)
                 + $GUTTER_SIZE_PX
                 + $ARTICLE_WIDTH_PX
             }px) !important;


### PR DESCRIPTION
I got these warnings when running `npm run build`:

    DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

    Recommendation: math.div($WRAPPER-WIDTH-NARROW-PX, 2)

    More info and automated migrator: https://sass-lang.com/d/slash-div

       ╷
    54 │                 - $WRAPPER_WIDTH_NARROW_PX/2
       │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
       ╵
        src/stylesheets/improved-corrections.scss 54:19  root stylesheet

👉 https://sass-lang.com/documentation/breaking-changes/slash-div

💡 `git show --color-words=.`