### PR TITLE
Use Node 16 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 16.x
       - name: Install dependencies
         run: |
           npm ci

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 16.x
       - name: Install dependencies
         run: |
           npm ci


### PR DESCRIPTION
I couldn't get `npm run build` to work with Node 18 locally due to some
"The callback was already called" error, so I'm going with Node 16 for
now.