### PR TITLE
Don't use `String.prototype.substr` (deprecated)

### DIFF
--- a/src/operations/autosave-draft.ts
+++ b/src/operations/autosave-draft.ts
@@ -185,6 +185,6 @@ function shortenedIfLongerThan(max: number, s: string): string {
     return (
         s.length <= max
             ? s
-            : s.substr(0, max/2) + "\n[…]\n" + s.substr(s.length - max/2)
+            : s.substring(0, max/2) + "\n[…]\n" + s.substring(s.length - max/2)
     );
 }


### PR DESCRIPTION
👉 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr

💡 `git show --color-words='\w+|.'`