### PR TITLE
Refactor user ID extraction

### DIFF
--- a/src/operations/pm-links.tsx
+++ b/src/operations/pm-links.tsx
@@ -15,7 +15,7 @@ export default () => {
     const forumPosts = document.getElementsByClassName(SITE.CLASS.forumPost);
     const user = SITE.getUserInfo();
     switch (user.tag) {
-        case "Unknown": return couldNotExtract("logged-in status and/or user ID");
+        case "CouldNotExtract": return couldNotExtract("logged-in status and/or user ID");
         case "NotLoggedIn": return; // No error; there's just nothing to do if the user is not logged in.
         case "LoggedIn": break;
         default: assertExhausted(user);

--- a/src/operations/pm-links.tsx
+++ b/src/operations/pm-links.tsx
@@ -9,17 +9,18 @@ import { insertAtTheEnd, renderIn } from "~src/operations/logic/render";
 import SELECTOR from "~src/selectors";
 import * as SITE from "~src/site";
 import * as T from "~src/text";
-import { r } from "~src/utilities";
+import { assertExhausted, r } from "~src/utilities";
 
 export default () => {
     const forumPosts = document.getElementsByClassName(SITE.CLASS.forumPost);
-    const ourUserID = SITE.getUserID();
-    if (ourUserID === undefined) {
-        return couldNotExtract("current user's ID");
+    const user = SITE.getUserInfo();
+    switch (user.tag) {
+        case "Unknown": return couldNotExtract("logged-in status and/or user ID");
+        case "NotLoggedIn": return; // No error; there's just nothing to do if the user is not logged in.
+        case "LoggedIn": break;
+        default: assertExhausted(user);
     }
-    if (ourUserID === SITE.USER_ID_NOT_LOGGED_IN) {
-        return;
-    }
+    const ourUserID = user.userID;
     const threadTitle = document.querySelector(SELECTOR.threadTitle)?.textContent;
     if (!isString(threadTitle)) {
         return couldNotExtract("thread title");

--- a/src/operations/prevent-accidental-signout.ts
+++ b/src/operations/prevent-accidental-signout.ts
@@ -1,16 +1,17 @@
 import SELECTOR from "~src/selectors";
 import * as SITE from "~src/site";
 import * as T from "~src/text";
+import { assertExhausted } from "~src/utilities";
 
 export default () => { // We can't take the signout button as a dependency, because it only exists on the user's own profile page.
-    const ourUserID = SITE.getUserID();
-    if (ourUserID === undefined) {
-        return `Could not extract current user's ID.`;
+    const user = SITE.getUserInfo();
+    switch (user.tag) {
+        case "Unknown": return "Could not extract logged-in status and/or user ID.";
+        case "NotLoggedIn": return; // No error; there's just nothing to do if the user is not logged in.
+        case "LoggedIn": break;
+        default: assertExhausted(user);
     }
-    const isNotLoggedIn = ourUserID === SITE.USER_ID_NOT_LOGGED_IN;
-    if (isNotLoggedIn) {
-        return;
-    }
+    const ourUserID = user.userID;
     const isOwnProfilePage = SITE.PATH.PROFILE(ourUserID).test(document.location.pathname);
     if (!isOwnProfilePage) {
         return;

--- a/src/operations/prevent-accidental-signout.ts
+++ b/src/operations/prevent-accidental-signout.ts
@@ -6,7 +6,7 @@ import { assertExhausted } from "~src/utilities";
 export default () => { // We can't take the signout button as a dependency, because it only exists on the user's own profile page.
     const user = SITE.getUserInfo();
     switch (user.tag) {
-        case "Unknown": return "Could not extract logged-in status and/or user ID.";
+        case "CouldNotExtract": return "Could not extract logged-in status and/or user ID.";
         case "NotLoggedIn": return; // No error; there's just nothing to do if the user is not logged in.
         case "LoggedIn": break;
         default: assertExhausted(user);

--- a/src/site.ts
+++ b/src/site.ts
@@ -167,7 +167,7 @@ export const MOBILE_SITE_DISCLAIMER = {
 const USER_ID_NOT_LOGGED_IN = 1;
 
 type UserInfo = (
-    | { tag: "Unknown" }
+    | { tag: "CouldNotExtract" }
     | { tag: "NotLoggedIn" }
     | { tag: "LoggedIn", userID: number }
 );
@@ -175,7 +175,7 @@ type UserInfo = (
 export function getUserInfo(): UserInfo {
     const userID: unknown = (window as any)?.session?._userid;
     if (typeof userID !== "number") {
-        return { tag: "Unknown" };
+        return { tag: "CouldNotExtract" };
     }
     return (
         userID === USER_ID_NOT_LOGGED_IN

--- a/src/site.ts
+++ b/src/site.ts
@@ -164,11 +164,24 @@ export const MOBILE_SITE_DISCLAIMER = {
     mobileSiteDomain: HOSTNAME_MOBILE,
 } as const;
 
-export const USER_ID_NOT_LOGGED_IN = 1;
+const USER_ID_NOT_LOGGED_IN = 1;
 
-export function getUserID(): number | undefined {
-    const userID = (window as any)?.session?._userid;
-    return typeof userID === "number" ? userID : undefined;
+type UserInfo = (
+    | { tag: "Unknown" }
+    | { tag: "NotLoggedIn" }
+    | { tag: "LoggedIn", userID: number }
+);
+
+export function getUserInfo(): UserInfo {
+    const userID: unknown = (window as any)?.session?._userid;
+    if (typeof userID !== "number") {
+        return { tag: "Unknown" };
+    }
+    return (
+        userID === USER_ID_NOT_LOGGED_IN
+            ? { tag: "NotLoggedIn" }
+            : { tag: "LoggedIn", userID }
+    );
 }
 
 export function isValidUsername(s: string): boolean {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -25,3 +25,7 @@ export function yyyymmdd(date: Date): string {
     const dd = date.getDate().toString().padStart(2, "0");
     return yyyy + mm + dd;
 }
+
+export function assertExhausted(x: never): never {
+    throw new Error(`assertExhausted: ${x}`);
+}


### PR DESCRIPTION
This PR replaces the crude `getUserID` function, which expects the caller to know that `undefined` and `1` represent "not possible to extract user info" and "not logged in", respectively, with a function with a much more explicit and descriptive return type.