### PR TITLE
Improve replace followed threads

### DIFF
--- a/src/operations/replace-followed-threads-link.ts
+++ b/src/operations/replace-followed-threads-link.ts
@@ -2,12 +2,21 @@ import { is } from "ts-type-guards";
 
 import * as SITE from "~src/site";
 import * as T from "~src/text";
+import { assertExhausted } from "~src/utilities";
 
 export default (e: { followedThreadsLinkTextOrSigninButton: HTMLElement }) => {
-    const notLoggedIn = is(HTMLAnchorElement)(e.followedThreadsLinkTextOrSigninButton);
-    if (notLoggedIn) return;
+    const user = SITE.getUserInfo();
+    switch (user.tag) {
+        case "CouldNotExtract": return "Could not extract logged-in status and/or user ID.";
+        case "NotLoggedIn": return; // No error; there's just nothing to do if the user is not logged in.
+        case "LoggedIn": break;
+        default: assertExhausted(user);
+    }
     const text = e.followedThreadsLinkTextOrSigninButton;
-    const link = text.parentElement as HTMLAnchorElement;
+    const link = text.parentElement;
+    if (!is(HTMLAnchorElement)(link)) {
+        return `Expected a link, but found an element with tagname ${JSON.stringify(link?.tagName)}.`;
+    }
     text.textContent = T.general.my_posts;
     link.href = SITE.PATH.MY_POSTS;
     link.classList.remove(SITE.CLASS.colorOrange);


### PR DESCRIPTION
This PR makes the implementation use the `getUserInfo` function (#251) instead of the type of `e.followedThreadsLinkTextOrSigninButton` to determine whether the user is logged in. Also, a type assertion is replaced with a type-guard application plus error reporting.