### PR TITLE
Patch preferences shortcut

### DIFF
--- a/src/site.ts
+++ b/src/site.ts
@@ -58,7 +58,7 @@ export const CLASS = {
     bbImage: "bbImage",
     bbIns: "bbIns",
     imgControls: "imgControls",
-    notifications: "pw-notifications",
+    notifications: "profile-nav__notifications",
     proofDialog: "proofDialog",
     socialMediaButtons: [ `threadShare`, `greyContentShare`, `sideShare` ],
     sideBox: "sideBox",
@@ -154,7 +154,7 @@ export const ICONS = {
     toolbarIcon: (position: string): string => `<div style="background-image: url('${URL_ICONS_TOOLBAR}'); background-size: 500px auto; background-position: ${position};"></div>`,
     position_toolbar_url: "0 -125px",
     position_toolbar_img: "-50px -125px",
-    settings: `<use xlink:href="#icon_settings"></use>`,
+    settings: `<use xlink:href="/gfx/iconmap.svg#icon_settings"></use>`,
 } as const;
 
 export const MOBILE_SITE_DISCLAIMER = {

--- a/src/stylesheets/preferences-shortcut.scss
+++ b/src/stylesheets/preferences-shortcut.scss
@@ -4,4 +4,15 @@
         margin-left: -34px; // Default icon width and right margin are 24px and 10px, respectively.
         z-index: 10; // so it's in front of the logo
     }
+
+    // This makes space for the preferences shortcut on desktop (narrow layout), so the built-in dark mode toggle isn't pushed to the left when the shortcut is inserted:
+    @media (min-width: 577px) { // SweClockers use `@media (min-width: 577px)` to switch between layouts.
+        width: 120px; // Each icon takes up 30px, including spacing.
+        justify-content: flex-end;
+    }
+
+    // This makes space for the preferences shortcut on desktop (wide layout), so the built-in dark mode toggle isn't pushed to the left when the shortcut is inserted:
+    @media (min-width: 993px) { // SweClockers use `@media (min-width: 993px)` to switch between layouts.
+        width: 346px; // 342px seems to be enough on my laptop, but I've decided to err on the side of caution since text rendering can vary between clients, zoom levels etc.
+    }
 }


### PR DESCRIPTION
I believe it was broken by the Dark Mode update.

👉 https://www.sweclockers.com/artikel/37572-antligen-halebop-fixar-morkt-tema-pa-sweclockers

The vanilla notification icons use `xlink:href` values like this one:

    /gfx/iconmap.svg?v=20230629#icon_quote

I assume that the purpose of `?v=20230629` is cache invalidation. We could probably extract it from one of the vanilla icons and use it for the preferences shortcut as well, but it doesn't feel worth it. If it ever breaks due to caching, then we can reconsider.

💡 `git show --color-words='pw-notifications|.'`