### PR TITLE
Add option to redirect home page to archive

### DIFF
--- a/src/operations.ts
+++ b/src/operations.ts
@@ -39,6 +39,7 @@ import preventAccidentalSignout from "./operations/prevent-accidental-signout";
 import * as preventAccidentalUnload from "./operations/prevent-accidental-unload";
 import * as Proofreading from "./operations/proofreading";
 import insertQuoteSignatureButtons from "./operations/quote-signature-buttons";
+import redirectHomePageToArchive from "./operations/redirect-home-page-to-archive";
 import rememberLocationInMarket from "./operations/remember-location-in-market";
 import removeMobileSiteDisclaimer from "./operations/remove-mobile-site-disclaimer";
 import replaceFollowedThreadsLink from "./operations/replace-followed-threads-link";
@@ -62,6 +63,16 @@ const OPERATIONS: readonly Operation<any>[] = [
         description: "set document id",
         condition: () => ALWAYS,
         action: () => { document.documentElement.id = CONFIG.ID.document; },
+    }),
+    operation({
+        description: "redirect front page to archive",
+        condition: () => !isOnBSCPreferencesPage && Preferences.get(P.general._.redirect_home_page_to_archive),
+        dependencies: {
+            headerLogoLink: `#${SITE.ID.header} a[href="/"]`,
+            latestNewsWidgetLink: `#${SITE.ID.latestNewsWidget} a[href="/"]`,
+            footerLogoLink: `#${SITE.ID.footer} a[href="/"]`,
+        },
+        action: redirectHomePageToArchive,
     }),
     operation({
         // I haven't managed to make this operation work at all in Firefox; the default action is just not overridden.

--- a/src/operations/redirect-home-page-to-archive.ts
+++ b/src/operations/redirect-home-page-to-archive.ts
@@ -1,0 +1,16 @@
+import * as SITE from "~src/site";
+
+export default (e: {
+    headerLogoLink: HTMLElement,
+    latestNewsWidgetLink: HTMLElement,
+    footerLogoLink: HTMLElement,
+}) => {
+    if (document.location.pathname === "/") {
+        document.location.pathname = SITE.PATH.ARCHIVE;
+    } else {
+        // Yes, this is repetitive. Yes, `Object.values` exists. But no, Userscripter (as of version 2.0.0) creates `e` with `Object.defineProperty` without the `enumerable` flag enabled, so `Object.values` returns the empty array.
+        (e.headerLogoLink as HTMLAnchorElement).href = SITE.PATH.ARCHIVE;
+        (e.latestNewsWidgetLink as HTMLAnchorElement).href = SITE.PATH.ARCHIVE;
+        (e.footerLogoLink as HTMLAnchorElement).href = SITE.PATH.ARCHIVE;
+    }
+};

--- a/src/preferences/general.ts
+++ b/src/preferences/general.ts
@@ -31,6 +31,12 @@ export default {
         label: T.preferences.general.replace_followed_threads_link,
         description: T.preferences.general.replace_followed_threads_link_description,
     }),
+    redirect_home_page_to_archive: new BooleanPreference({
+        key: "redirect_home_page_to_archive",
+        default: false,
+        label: T.preferences.general.redirect_home_page_to_archive,
+        description: T.preferences.general.redirect_home_page_to_archive_description,
+    }),
     remember_location_in_market: new BooleanPreference({
         key: "remember_location_in_market",
         default: true,

--- a/src/site.ts
+++ b/src/site.ts
@@ -21,6 +21,7 @@ export const WIDTH_WHERE_WIDE_LAYOUT_GOES_CENTERED = WRAPPER_WIDTH_WIDE_PX + 2 *
 
 export const ID = {
     header: "header",
+    footer: "footer",
     carousel: "carousel",
     correctionsLink: "proofArticle",
     postPreview: "preview",
@@ -95,6 +96,7 @@ export const PATH = {
         link: "/profil/installningar", // Relying on this path being redirected to the actual settings path allows us to create a link to the preferences page without knowing the user's ID.
         check: /^\/medlem\/\d+\/installningar/, // Should not have a "$" because it should match subpaths too.
     },
+    ARCHIVE: "/arkiv",
     FOLLOWED: "/forum/foljda",
     MY_POSTS: "/profil/inlagg",
     SIGNIN: `/konto/logga-in`,

--- a/src/text.ts
+++ b/src/text.ts
@@ -65,6 +65,8 @@ export const preferences = {
         insert_preferences_shortcut_description: `Visa en länk till ${CONFIG.USERSCRIPT_NAME} inställningsmeny högst upp`,
         replace_followed_threads_link: `Ersätt länken <em>Följda trådar</em> med <em>${my_posts}</em>`,
         replace_followed_threads_link_description: OBVIOUS,
+        redirect_home_page_to_archive: `Peka om startsidan till arkivet`,
+        redirect_home_page_to_archive_description: `För dig som föredrar kronologisk ordning i nyhetsflödet`,
         remember_location_in_market: `Kom ihåg min plats i marknaden`,
         remember_location_in_market_description: `Slipp fylla i län och stad varje gång du skapar en annons`,
     },


### PR DESCRIPTION
Some users don't like the home page because it doesn't show content in chronological order: articles from several days ago are sometimes bumped, etc. The general consensus, and [explicit recommendation from SweClockers themselves][recommendation], is to use the archive page instead for those who prefer chronological order.

This PR adds an option to redirect the home page to the archive and modify the internal links to the home page to point to the archive instead, as [suggested] by [evil penguin] @ SweClockers. (One might argue that the links need not be modified, since the user will be redirected anyway, but that would be slower, use more data and possibly make the home page appear more popular than it actually is.)

[recommendation]: https://www.sweclockers.com/forum/post/20374336
[suggested]: https://www.sweclockers.com/forum/post/20374374
[evil penguin]: https://www.sweclockers.com/medlem/8224