### PR TITLE
Upgrade to Userscripter 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "ts-type-guards": "^0.6.1",
         "typescript": "4.1.6",
         "userscript-metadata": "^1.0.0",
-        "userscripter": "^2.0.0",
+        "userscripter": "3.0.0",
         "webpack": "^4.46.0",
         "webpack-cli": "^3.3.12"
       }
@@ -3152,9 +3152,9 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "node_modules/@types/loader-utils": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@types/loader-utils/-/loader-utils-1.1.6.tgz",
-      "integrity": "sha512-0U4S5kLpm3Cu9YkO46JrmujS2abL2tWsxA1SR8km6X0a1E96tfPu34zRdQSZsJ6dfRYwQpmuKmy9Mx2Od7AXag==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@types/loader-utils/-/loader-utils-1.1.9.tgz",
+      "integrity": "sha512-2NrfPIjGI8ZuEBtMQHQ71Rf+dyZayiuf4EyJYBTvh5fbNLAmQ7AIpjbPRJ5CXEBJVfSgtoi02pI/yNaVAgxMYg==",
       "dependencies": {
         "@types/node": "*",
         "@types/webpack": "^4"
@@ -16437,30 +16437,6 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "deprecated": "https://github.com/lydell/resolve-url#deprecated"
     },
-    "node_modules/restrict-imports-loader": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/restrict-imports-loader/-/restrict-imports-loader-3.2.6.tgz",
-      "integrity": "sha512-n7aDGBo4JaxMxjlJ8AmRO1zuzMBzWPaSP0Oo5saA6m3DIj/7Mz++JeE2TYiryFNkDWov3v5EWlYN4d16Q4UsAQ==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.3",
-        "@types/loader-utils": "^1.1.3",
-        "loader-utils": "^1.2.3",
-        "schema-utils": "^2.5.0",
-        "typescript": "^3.7.2"
-      }
-    },
-    "node_modules/restrict-imports-loader/node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -18397,9 +18373,9 @@
       }
     },
     "node_modules/userscripter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-2.0.0.tgz",
-      "integrity": "sha512-p53sr/U8fWzbx5PgPB5XfTk5smvaq4bxdqRcP4yv6ZxKD/+3WEArubWtCiMgdAPX9nR4bWgZuSirSqAR9qVg3Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-3.0.0.tgz",
+      "integrity": "sha512-aa4KvpKilmQJMC3/x9kpPDNNgjMKTuUof+PdsVFs3HO6yKZp7MhXFmdSAjzzSy3UvRrnjmiD4LCFnlHJTsqxYg==",
       "dependencies": {
         "@types/fs-extra": "^8.0.1",
         "@types/json-schema": "^7.0.3",
@@ -18415,7 +18391,6 @@
         "loader-utils": "^1.2.3",
         "node-sass-utils": "^1.1.3",
         "raw-loader": "^4.0.0",
-        "restrict-imports-loader": "^3.2.5",
         "sass": "^1.32.8",
         "sass-loader": "10.1.1",
         "schema-utils": "^2.5.0",
@@ -21863,9 +21838,9 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "@types/loader-utils": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@types/loader-utils/-/loader-utils-1.1.6.tgz",
-      "integrity": "sha512-0U4S5kLpm3Cu9YkO46JrmujS2abL2tWsxA1SR8km6X0a1E96tfPu34zRdQSZsJ6dfRYwQpmuKmy9Mx2Od7AXag==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@types/loader-utils/-/loader-utils-1.1.9.tgz",
+      "integrity": "sha512-2NrfPIjGI8ZuEBtMQHQ71Rf+dyZayiuf4EyJYBTvh5fbNLAmQ7AIpjbPRJ5CXEBJVfSgtoi02pI/yNaVAgxMYg==",
       "requires": {
         "@types/node": "*",
         "@types/webpack": "^4"
@@ -32107,25 +32082,6 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
-    "restrict-imports-loader": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/restrict-imports-loader/-/restrict-imports-loader-3.2.6.tgz",
-      "integrity": "sha512-n7aDGBo4JaxMxjlJ8AmRO1zuzMBzWPaSP0Oo5saA6m3DIj/7Mz++JeE2TYiryFNkDWov3v5EWlYN4d16Q4UsAQ==",
-      "requires": {
-        "@types/json-schema": "^7.0.3",
-        "@types/loader-utils": "^1.1.3",
-        "loader-utils": "^1.2.3",
-        "schema-utils": "^2.5.0",
-        "typescript": "^3.7.2"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "3.9.10",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
-        }
-      }
-    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -33592,9 +33548,9 @@
       }
     },
     "userscripter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-2.0.0.tgz",
-      "integrity": "sha512-p53sr/U8fWzbx5PgPB5XfTk5smvaq4bxdqRcP4yv6ZxKD/+3WEArubWtCiMgdAPX9nR4bWgZuSirSqAR9qVg3Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-3.0.0.tgz",
+      "integrity": "sha512-aa4KvpKilmQJMC3/x9kpPDNNgjMKTuUof+PdsVFs3HO6yKZp7MhXFmdSAjzzSy3UvRrnjmiD4LCFnlHJTsqxYg==",
       "requires": {
         "@types/fs-extra": "^8.0.1",
         "@types/json-schema": "^7.0.3",
@@ -33610,7 +33566,6 @@
         "loader-utils": "^1.2.3",
         "node-sass-utils": "^1.1.3",
         "raw-loader": "^4.0.0",
-        "restrict-imports-loader": "^3.2.5",
         "sass": "^1.32.8",
         "sass-loader": "10.1.1",
         "schema-utils": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ts-type-guards": "^0.6.1",
     "typescript": "4.1.6",
     "userscript-metadata": "^1.0.0",
-    "userscripter": "^2.0.0",
+    "userscripter": "3.0.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   }


### PR DESCRIPTION
Today, an import like

    import * as build from "userscripter/build";

    void build;

in the run-time code (everything in `src/`) makes `npm run build` fail like this:

    ERROR in ./src/main.ts
    Module build failed (from ./node_modules/restrict-imports-loader/dist/index.js):
    Error: "userscripter/build" and its submodules cannot be imported in the source directory ('src'). Please remove these imports:
    
      • "userscripter/build", imported on line 3:
    
            import * as build from "userscripter/build";

With Userscripter 3.0.0, it instead fails with an unintelligible wall of text containing, among others, these errors:

  * `Critical dependency: require function is used in a way in which dependencies cannot be statically extracted`
  * `Critical dependency: the request of a dependency is an expression`
  * `Module not found: Error: Can't resolve 'fsevents' in '/home/alling/dev/better-sweclockers/node_modules/chokidar/lib'`
  * `System.import() is deprecated and will be removed soon. Use import() instead.`
  * `require.extensions is not supported by webpack. Use a loader instead.`
  * `Can't import the named export 'RawSource' from non EcmaScript module (only default export is available)`

That in itself is of course a downgrade, but I want to upgrade Userscripter as new versions are released unless there is a compelling reason not to.