### PR TITLE
Upgrade to Userscripter 3.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "ts-type-guards": "^0.6.1",
         "typescript": "4.1.6",
         "userscript-metadata": "^1.0.0",
-        "userscripter": "3.0.1",
+        "userscripter": "3.0.5",
         "webpack": "^4.46.0",
         "webpack-cli": "^3.3.12"
       }
@@ -3150,15 +3150,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
-    },
-    "node_modules/@types/loader-utils": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@types/loader-utils/-/loader-utils-1.1.9.tgz",
-      "integrity": "sha512-2NrfPIjGI8ZuEBtMQHQ71Rf+dyZayiuf4EyJYBTvh5fbNLAmQ7AIpjbPRJ5CXEBJVfSgtoi02pI/yNaVAgxMYg==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/webpack": "^4"
-      }
     },
     "node_modules/@types/milliseconds": {
       "version": "0.0.29",
@@ -18373,13 +18364,11 @@
       }
     },
     "node_modules/userscripter": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-3.0.1.tgz",
-      "integrity": "sha512-1+10SVd6GLdxKgdo89xSKqD62dt0a7GWj54fGzk9YWJzeVFsTCB19UYVqkh1QKpFW0MK74SPO28qUDwAP5rveA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-3.0.5.tgz",
+      "integrity": "sha512-yFCQSEWp+J25B+5/7dEF6txewMc7OYCvyeOt9cikwGqigA/PLhRF70RjnKq6MI5hJO/HgYVgVmXk5rgR+mHx+g==",
       "dependencies": {
         "@types/fs-extra": "^8.0.1",
-        "@types/json-schema": "^7.0.3",
-        "@types/loader-utils": "^1.1.3",
         "@types/node": "^12.12.8",
         "@types/sass": "^1.16.0",
         "@types/terser-webpack-plugin": "^2.2.0",
@@ -18388,12 +18377,10 @@
         "css-loader": "^3.2.0",
         "fs-extra": "^8.1.0",
         "lines-unlines": "^1.0.0",
-        "loader-utils": "^1.2.3",
         "node-sass-utils": "^1.1.3",
         "raw-loader": "^4.0.0",
         "sass": "^1.32.8",
         "sass-loader": "10.1.1",
-        "schema-utils": "^2.5.0",
         "terser-webpack-plugin": "^2.3.1",
         "to-string-loader": "^1.1.6",
         "ts-loader": "^8.4.0",
@@ -21836,15 +21823,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
-    },
-    "@types/loader-utils": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@types/loader-utils/-/loader-utils-1.1.9.tgz",
-      "integrity": "sha512-2NrfPIjGI8ZuEBtMQHQ71Rf+dyZayiuf4EyJYBTvh5fbNLAmQ7AIpjbPRJ5CXEBJVfSgtoi02pI/yNaVAgxMYg==",
-      "requires": {
-        "@types/node": "*",
-        "@types/webpack": "^4"
-      }
     },
     "@types/milliseconds": {
       "version": "0.0.29",
@@ -33548,13 +33526,11 @@
       }
     },
     "userscripter": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-3.0.1.tgz",
-      "integrity": "sha512-1+10SVd6GLdxKgdo89xSKqD62dt0a7GWj54fGzk9YWJzeVFsTCB19UYVqkh1QKpFW0MK74SPO28qUDwAP5rveA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-3.0.5.tgz",
+      "integrity": "sha512-yFCQSEWp+J25B+5/7dEF6txewMc7OYCvyeOt9cikwGqigA/PLhRF70RjnKq6MI5hJO/HgYVgVmXk5rgR+mHx+g==",
       "requires": {
         "@types/fs-extra": "^8.0.1",
-        "@types/json-schema": "^7.0.3",
-        "@types/loader-utils": "^1.1.3",
         "@types/node": "^12.12.8",
         "@types/sass": "^1.16.0",
         "@types/terser-webpack-plugin": "^2.2.0",
@@ -33563,12 +33539,10 @@
         "css-loader": "^3.2.0",
         "fs-extra": "^8.1.0",
         "lines-unlines": "^1.0.0",
-        "loader-utils": "^1.2.3",
         "node-sass-utils": "^1.1.3",
         "raw-loader": "^4.0.0",
         "sass": "^1.32.8",
         "sass-loader": "10.1.1",
-        "schema-utils": "^2.5.0",
         "terser-webpack-plugin": "^2.3.1",
         "to-string-loader": "^1.1.6",
         "ts-loader": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ts-type-guards": "^0.6.1",
     "typescript": "4.1.6",
     "userscript-metadata": "^1.0.0",
-    "userscripter": "3.0.1",
+    "userscripter": "3.0.5",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   }


### PR DESCRIPTION
The v3.x releases after v3.0.5 only affect the CLI tool, not the library.