### PR TITLE
Upgrade to Userscripter 5.0.0

### DIFF
--- a/metadata.ts
+++ b/metadata.ts
@@ -2,7 +2,7 @@ import { Metadata } from "userscript-metadata";
 import {
     BuildConfig,
     metadataUrl,
-} from "userscripter/build";
+} from "userscripter/build-time";
 
 import U from "./src/userscript";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "ts-type-guards": "^0.6.1",
         "typescript": "4.1.6",
         "userscript-metadata": "^1.0.0",
-        "userscripter": "4.0.0",
+        "userscripter": "5.0.0",
         "webpack": "^4.46.0",
         "webpack-cli": "^3.3.12"
       }
@@ -18330,9 +18330,9 @@
       }
     },
     "node_modules/userscripter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-4.0.0.tgz",
-      "integrity": "sha512-KHdpe173p179cAYURkI1G251jxjhF7tTLX74TfRGRKL0MWqR2N+YpMDd5dUxqk2cU6aVv85igswEohPRsgD2cg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-5.0.0.tgz",
+      "integrity": "sha512-lIvXdu16SFu3UqhfgincC6FPGsIxx7CW27ZAGkKfneYkqgOswEuJleI6R76d2M+C9vHNL/OibGpJktkuQak0mA==",
       "dependencies": {
         "@types/sass": "^1.16.0",
         "@types/terser-webpack-plugin": "^2.2.0",
@@ -33446,9 +33446,9 @@
       }
     },
     "userscripter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-4.0.0.tgz",
-      "integrity": "sha512-KHdpe173p179cAYURkI1G251jxjhF7tTLX74TfRGRKL0MWqR2N+YpMDd5dUxqk2cU6aVv85igswEohPRsgD2cg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-5.0.0.tgz",
+      "integrity": "sha512-lIvXdu16SFu3UqhfgincC6FPGsIxx7CW27ZAGkKfneYkqgOswEuJleI6R76d2M+C9vHNL/OibGpJktkuQak0mA==",
       "requires": {
         "@types/sass": "^1.16.0",
         "@types/terser-webpack-plugin": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ts-type-guards": "^0.6.1",
     "typescript": "4.1.6",
     "userscript-metadata": "^1.0.0",
-    "userscripter": "4.0.0",
+    "userscripter": "5.0.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   }

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -1,5 +1,5 @@
-import { DOMCONTENTLOADED } from "userscripter/lib/environment";
-import { Operation, operation } from "userscripter/lib/operations";
+import { DOMCONTENTLOADED } from "userscripter/run-time/environment";
+import { Operation, operation } from "userscripter/run-time/operations";
 
 import * as CONFIG from "~src/config";
 import {

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -1,5 +1,5 @@
 import { PreferenceManager } from "ts-preferences";
-import { loggingResponseHandler, subscriptable } from "userscripter/lib/preferences";
+import { loggingResponseHandler, subscriptable } from "userscripter/run-time/preferences";
 
 import * as CONFIG from "~src/config";
 import * as T from "~src/text";

--- a/src/stylesheets.ts
+++ b/src/stylesheets.ts
@@ -1,6 +1,6 @@
 import * as ms from "milliseconds";
-import { ALWAYS } from "userscripter/lib/environment";
-import { Stylesheets, stylesheet } from "userscripter/lib/stylesheets";
+import { ALWAYS } from "userscripter/run-time/environment";
+import { Stylesheets, stylesheet } from "userscripter/run-time/stylesheets";
 
 import * as CONFIG from "~src/config";
 import { isInEditMode, isOnBSCPreferencesPage, isOnSweclockersSettingsPage, isReadingThread } from "~src/environment";

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -4,7 +4,7 @@ import {
     distFileName,
     DEFAULT_BUILD_CONFIG,
     DEFAULT_METADATA_SCHEMA,
-} from "userscripter/build";
+} from "userscripter/build-time";
 import * as webpack from "webpack";
 import { RawSource } from "webpack-sources";
 


### PR DESCRIPTION
I used this command to adapt the source code, as suggested in SimonAlling/userscripter#153:

```bash
for f in $(git ls-files "$(git rev-parse --show-toplevel)"); do
  sed -i 's#userscripter/build#userscripter/build-time#g' $f
  sed -i 's#userscripter/lib#userscripter/run-time#g' $f
done
```

💡 `git show --color-words='build-time|(\w|\+|=)+|.'`