### PR TITLE
Patch stylesheet URL

### DIFF
--- a/src/site.ts
+++ b/src/site.ts
@@ -6,7 +6,7 @@ export const NAME = U.sitename;
 export const HOSTNAME = U.hostname;
 export const HOSTNAME_MOBILE = `m.` + HOSTNAME;
 
-export const STYLESHEET_URL = (yyyymmdd: string) => `/css/combine.min.sass.css?v=${yyyymmdd}`;
+export const STYLESHEET_URL = (yyyymmdd: string) => `/css/main.css?v=${yyyymmdd}`;
 
 export const BANNER_HEIGHT_SIDE = `${370}px`; // default height of sidebar ad modules
 export const BANNER_HEIGHT_MID = `${341}px`; // default height of front page inter-article ad modules


### PR DESCRIPTION
On [the settings page], the editing tools are completely broken, as if they don't have any CSS at all, and this error is logged in the console (in Firefox):

    The resource from “https://www.sweclockers.com/css/combine.min.sass.css?v=20240801” was blocked due to MIME type (“text/html”) mismatch (X-Content-Type-Options: nosniff).

At the time of writing, the front page requests this URL:

    https://www.sweclockers.com/css/main.css?v=20240628

So we just have to update our corresponding URL.

💡 `git show --color-words='\w+|.'`

[the settings page]: https://www.sweclockers.com/profil/installningar/better-sweclockers