### PR TITLE
Lock height of inter-post ads on mobile

### DIFF
--- a/src/site.ts
+++ b/src/site.ts
@@ -10,6 +10,7 @@ export const STYLESHEET_URL = (yyyymmdd: string) => `/css/main.css?v=${yyyymmdd}
 
 export const BANNER_HEIGHT_SIDE = `${370}px`; // default height of sidebar ad modules
 export const BANNER_HEIGHT_MID = `${341}px`; // default height of front page inter-article ad modules
+export const BANNER_HEIGHT_BETWEEN_FORUM_POSTS = `${320}px`; // default height of forum-thread inter-post ad modules on mobile (or just narrow viewport in general)
 export const WRAPPER_WIDTH_WIDE_PX = 1250;
 export const WRAPPER_WIDTH_NARROW_PX = 1000;
 export const MAX_WIDTH_FOR_NARROW_LAYOUT_PX = 1100;

--- a/src/stylesheets/lock-heights.scss
+++ b/src/stylesheets/lock-heights.scss
@@ -7,3 +7,8 @@
     height: getGlobal("SITE.BANNER_HEIGHT_MID");
     overflow: hidden;
 }
+
+.ad.adForum {
+    height: getGlobal("SITE.BANNER_HEIGHT_BETWEEN_FORUM_POSTS");
+    overflow: hidden;
+}


### PR DESCRIPTION
On mobile (or whenever `@media (min-width: 577px)` is false), SweClockers shows ads between forum posts. Unfortunately, their containers don't have a height of their own, so everything below an ad is pushed down when the ad loads. This is very disorienting and annoying, as can be seen by going to [this post] on mobile (or in a narrow window) and scrolling up just a few centimeters or so before the ad loads.

This PR locks the height of inter-post ads to `320px`, which seems to be the actual height of all of them.

[this post]: https://www.sweclockers.com/forum/post/17706168