### PR TITLE
Upgrade to Userscripter 6.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 22.14.0
       - name: Install dependencies
         run: |
           npm ci

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 22.14.0
       - name: Install dependencies
         run: |
           npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "ts-type-guards": "^0.6.1",
         "typescript": "4.1.6",
         "userscript-metadata": "^1.0.0",
-        "userscripter": "5.1.0",
+        "userscripter": "6.0.0",
         "webpack": "^4.46.0",
         "webpack-cli": "^3.3.12"
       }
@@ -18327,9 +18327,9 @@
       }
     },
     "node_modules/userscripter": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-5.1.0.tgz",
-      "integrity": "sha512-S4AWay87wDU0iXPJJW3yhWfnIZQq3HlRl1HfLOHVlSL3eAWa89IIriNFJFW3FrIxVH9+4SafYCdoi9iKn9elQA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-6.0.0.tgz",
+      "integrity": "sha512-y0KFhrMgxh3o9PNjGHWNK7u9J9tJJPmLJ/LVnFWgbD8Z4OvHzCbEwa/7PsaL+xdI5/ggQ+xLtAOx8kLHjV/otA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "16.18.31",
@@ -33442,9 +33442,9 @@
       }
     },
     "userscripter": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-5.1.0.tgz",
-      "integrity": "sha512-S4AWay87wDU0iXPJJW3yhWfnIZQq3HlRl1HfLOHVlSL3eAWa89IIriNFJFW3FrIxVH9+4SafYCdoi9iKn9elQA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-6.0.0.tgz",
+      "integrity": "sha512-y0KFhrMgxh3o9PNjGHWNK7u9J9tJJPmLJ/LVnFWgbD8Z4OvHzCbEwa/7PsaL+xdI5/ggQ+xLtAOx8kLHjV/otA==",
       "requires": {
         "@types/node": "16.18.31",
         "@types/sass": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ts-type-guards": "^0.6.1",
     "typescript": "4.1.6",
     "userscript-metadata": "^1.0.0",
-    "userscripter": "5.1.0",
+    "userscripter": "6.0.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   }


### PR DESCRIPTION
Userscripter 6.0.0 dropped support for Node 16 in favor of Node 22 (see SimonAlling/userscripter#170).

I'm going with `22.14.0` instead of `22.x` to minimize non-determinism.