### PR TITLE
Remove obsolete and buggy PM links error handling

### DIFF
--- a/src/operations/pm-links.tsx
+++ b/src/operations/pm-links.tsx
@@ -26,51 +26,47 @@ export default () => {
         return couldNotExtract("thread title");
     }
     for (const post of only(HTMLElement)(Array.from(forumPosts))) {
-        try {
-            const profileDetails = post.querySelector("." + SITE.CLASS.forumPostProfileDetails);
-            const quoteButton = post.querySelector<HTMLAnchorElement>(SELECTOR.quoteButton);
-            const authorName = post.querySelector(SELECTOR.forumPostAuthorLink)?.textContent;
-            if (!isString(authorName)) return couldNotExtractFromPost("author name", post.id);
-            if (profileDetails === null) return couldNotExtractFromPost("profile details", post.id);
-            if (quoteButton === null) return couldNotExtractFromPost("quote button", post.id);
-            renderIn(profileDetails, insertAtTheEnd, (
-                <button
-                    dangerouslySetInnerHTML={{__html: ICON + T.general.pm_link_label}}
-                    onClick={() => {
-                        fetch(quoteButton.href, { credentials: "same-origin" }) // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters
-                            .then(response => response.text())
-                            .then(responseContent => {
-                                const responseDocument = new DOMParser().parseFromString(responseContent, "text/html");
-                                const quoteTextarea = responseDocument.querySelector("textarea");
-                                if (quoteTextarea === null) {
-                                    throw couldNotExtract("textarea from fetch response");
-                                }
-                                const form = document.createElement("form");
-                                form.hidden = true;
-                                form.method = "post";
-                                form.action = SITE.PATH.newPrivateMessage(ourUserID);
-                                renderIn(form, insertAtTheEnd, (
-                                    <>
-                                        <input name={SITE.FORM.name.recipients} value={authorName} />
-                                        <input name={SITE.FORM.name.title} value={threadTitle} />
-                                        <input name={SITE.FORM.name.csrfToken} value={session.getCsrfToken()} />
-                                        <input name={SITE.FORM.name.action} value="doPreview" />
-                                        <textarea name={SITE.FORM.name.message}>
-                                            {withLinksInsteadOfPostIDs(quoteTextarea.textContent || "")}
-                                        </textarea>
-                                    </>
-                                ));
-                                profileDetails.appendChild(form); // Otherwise: "Form submission canceled because the form is not connected"
-                                form.submit();
-                            })
-                            .catch(log.error);
-                    }}
-                    class={[ SITE.CLASS.button, CONFIG.CLASS.iconButton, CONFIG.CLASS.pmButton ].join(" ")}
-                ></button>
-            ));
-        } catch (err) {
-            return err;
-        }
+        const profileDetails = post.querySelector("." + SITE.CLASS.forumPostProfileDetails);
+        const quoteButton = post.querySelector<HTMLAnchorElement>(SELECTOR.quoteButton);
+        const authorName = post.querySelector(SELECTOR.forumPostAuthorLink)?.textContent;
+        if (!isString(authorName)) return couldNotExtractFromPost("author name", post.id);
+        if (profileDetails === null) return couldNotExtractFromPost("profile details", post.id);
+        if (quoteButton === null) return couldNotExtractFromPost("quote button", post.id);
+        renderIn(profileDetails, insertAtTheEnd, (
+            <button
+                dangerouslySetInnerHTML={{__html: ICON + T.general.pm_link_label}}
+                onClick={() => {
+                    fetch(quoteButton.href, { credentials: "same-origin" }) // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters
+                        .then(response => response.text())
+                        .then(responseContent => {
+                            const responseDocument = new DOMParser().parseFromString(responseContent, "text/html");
+                            const quoteTextarea = responseDocument.querySelector("textarea");
+                            if (quoteTextarea === null) {
+                                throw couldNotExtract("textarea from fetch response");
+                            }
+                            const form = document.createElement("form");
+                            form.hidden = true;
+                            form.method = "post";
+                            form.action = SITE.PATH.newPrivateMessage(ourUserID);
+                            renderIn(form, insertAtTheEnd, (
+                                <>
+                                    <input name={SITE.FORM.name.recipients} value={authorName} />
+                                    <input name={SITE.FORM.name.title} value={threadTitle} />
+                                    <input name={SITE.FORM.name.csrfToken} value={session.getCsrfToken()} />
+                                    <input name={SITE.FORM.name.action} value="doPreview" />
+                                    <textarea name={SITE.FORM.name.message}>
+                                        {withLinksInsteadOfPostIDs(quoteTextarea.textContent || "")}
+                                    </textarea>
+                                </>
+                            ));
+                            profileDetails.appendChild(form); // Otherwise: "Form submission canceled because the form is not connected"
+                            form.submit();
+                        })
+                        .catch(log.error);
+                }}
+                class={[ SITE.CLASS.button, CONFIG.CLASS.iconButton, CONFIG.CLASS.pmButton ].join(" ")}
+            ></button>
+        ));
     }
 };
 


### PR DESCRIPTION
The PM links feature was added in f9fa14e915875fb30a110a27ef7f95858587ee62. I assume the `try … catch` was intended to catch errors thrown by `JSON.parse`. At that point, the `catch` clause would return `FAILURE` – a `boolean`, which [was correct].

In b996a2b45b76aba9478f0046bc2bb3f7d24c0954, the operation was modified so that the `catch` clause would instead return `err` – statically an `any`, but at run time probably a `SyntaxError` thrown by `JSON.parse`. As far as I can tell, that's a bug, because a `SyntaxError` [would have been interpreted as operation success][interpreted], which is obviously completely incorrect. I believe the right thing would have been to return a `string`; see `git grep err.toString`.

In #243, the `JSON.parse` application was removed; I _think_ the (incorrectly implemented) `try … catch` has been unnecessary ever since.

[was correct]: https://github.com/SimonAlling/better-sweclockers/blob/f9fa14e915875fb30a110a27ef7f95858587ee62/.userscripter/lib/operation-manager.ts#L88
[interpreted]: https://github.com/SimonAlling/userscripter/blob/v1.1.0/src/lib/operations.ts#L126