### PR TITLE
Upgrade to TypeScript 4.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "ts-preferences": "^2.0.0",
         "ts-storage": "^5.0.1",
         "ts-type-guards": "^0.6.1",
-        "typescript": "4.3.5",
+        "typescript": "4.4.4",
         "userscript-metadata": "^1.0.0",
         "userscripter": "6.0.0",
         "webpack": "^4.46.0",
@@ -18247,9 +18247,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -33461,9 +33461,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA=="
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ts-preferences": "^2.0.0",
     "ts-storage": "^5.0.1",
     "ts-type-guards": "^0.6.1",
-    "typescript": "4.3.5",
+    "typescript": "4.4.4",
     "userscript-metadata": "^1.0.0",
     "userscripter": "6.0.0",
     "webpack": "^4.46.0",

--- a/src/operations/draft-mode-toggle.ts
+++ b/src/operations/draft-mode-toggle.ts
@@ -27,7 +27,7 @@ export default (e: {
     apply(draftModeEnabled, saveButton);
 };
 
-function toggle(checkbox: HTMLInputElement, saveButton: HTMLButtonElement): EventHandlerNonNull {
+function toggle(checkbox: HTMLInputElement, saveButton: HTMLButtonElement): (_: Event) => void {
     return _ => {
         const draftModeEnabled = checkbox.checked;
         Storage.set_session(CONFIG.KEY.draft_mode, draftModeEnabled);

--- a/src/operations/improved-builtin-editing-tools-url.ts
+++ b/src/operations/improved-builtin-editing-tools-url.ts
@@ -7,6 +7,7 @@ import { insertIn, selectRangeIn, selectedTextIn } from "~src/operations/logic/t
 import SELECTOR from "~src/selectors";
 import * as SITE from "~src/site";
 import * as T from "~src/text";
+import { errorMessageFromCaught } from "~src/utilities";
 
 declare namespace Beta { const Forms: any; }
 declare namespace Taiga { const Strings: any; }
@@ -68,7 +69,7 @@ export default (undoSupport: boolean) => () => {
             }
         };
     } catch (err) {
-        return err.toString(); // String conversion is necessary for the error to be handled properly by Userscripter.
+        return errorMessageFromCaught(err); // String conversion is necessary for the error to be handled properly by Userscripter.
     }
 };
 

--- a/src/operations/improved-builtin-editing-tools.ts
+++ b/src/operations/improved-builtin-editing-tools.ts
@@ -1,3 +1,5 @@
+import { errorMessageFromCaught } from "~src/utilities";
+
 import { insertIn, wrapIn } from "./logic/textarea";
 
 declare namespace Tanuki { const Templates: any; }
@@ -22,6 +24,6 @@ export default () => {
             }
         };
     } catch (err) {
-        return err.toString(); // String conversion is necessary for the error to be handled properly by Userscripter.
+        return errorMessageFromCaught(err); // String conversion is necessary for the error to be handled properly by Userscripter.
     }
 };

--- a/src/preferences-menu.tsx
+++ b/src/preferences-menu.tsx
@@ -48,7 +48,7 @@ function fromStringEventHandler<
     E extends HTMLElement & { value: string },
     T extends AllowedTypes,
     P extends Preference<T> & FromString<T>,
->(p: P): EventHandlerNonNull {
+>(p: P): (e: Event) => void {
     return (e: Event) => {
         const parsed = p.fromString((e.target as E).value);
         if (isString(parsed)) {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -29,3 +29,7 @@ export function yyyymmdd(date: Date): string {
 export function assertExhausted(x: never): never {
     throw new Error(`assertExhausted: ${x}`);
 }
+
+export function errorMessageFromCaught(caught: unknown): string {
+    return caught instanceof Error ? caught.message : typeof caught === "string" ? caught : JSON.stringify(caught);
+}


### PR DESCRIPTION
I did this:

    npm install --save-exact typescript@4.4

Then I got these errors when running `npm run build`:

    ERROR in /…/src/preferences-menu.tsx
    ./src/preferences-menu.tsx 51:9-28
    [tsl] ERROR in /…/src/preferences-menu.tsx(51,10)
          TS2304: Cannot find name 'EventHandlerNonNull'.

    ERROR in /…/src/operations/draft-mode-toggle.ts
    ./src/operations/draft-mode-toggle.ts 30:76-95
    [tsl] ERROR in /…/src/operations/draft-mode-toggle.ts(30,77)
          TS2304: Cannot find name 'EventHandlerNonNull'.

    ERROR in /…/src/operations/draft-mode-toggle.ts
    ./src/operations/draft-mode-toggle.ts 31:11-12
    [tsl] ERROR in /…/src/operations/draft-mode-toggle.ts(31,12)
          TS7006: Parameter '_' implicitly has an 'any' type.

    ERROR in /…/src/operations/improved-builtin-editing-tools-url.ts
    ./src/operations/improved-builtin-editing-tools-url.ts 71:15-18
    [tsl] ERROR in /…/src/operations/improved-builtin-editing-tools-url.ts(71,16)
          TS2571: Object is of type 'unknown'.

    ERROR in /…/src/operations/improved-builtin-editing-tools.ts
    ./src/operations/improved-builtin-editing-tools.ts 25:15-18
    [tsl] ERROR in /…/src/operations/improved-builtin-editing-tools.ts(25,16)
          TS2571: Object is of type 'unknown'.

I solved them like this:

  * `EventHandlerNonNull` was defined like this in TypeScript 4.3.5:

    ```typescript
    interface EventHandlerNonNull {
        (event: Event): any;
    }
    ```

    I replaced it with `(e: Event) => void`, which made sense for our use cases. That fixed the first three errors above.

  * TypeScript 4.4 [introduced the `useUnknownInCatchVariables` compiler option][useUnknownInCatchVariables], which defaults to `true` when `strict` is `true`. I used my trusty old `errorMessageFromCaught` utility function to fix the two resulting type errors.

[useUnknownInCatchVariables]: https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#defaulting-to-the-unknown-type-in-catch-variables-(--useunknownincatchvariables)

💡 `git show --color-words='4\.3\.5|\(\)|\w+|.'`