### PR TITLE
Upgrade to TypeScript 4.9.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "ts-preferences": "^2.0.0",
         "ts-storage": "^5.0.1",
         "ts-type-guards": "^0.6.1",
-        "typescript": "4.5.5",
+        "typescript": "4.9.5",
         "userscript-metadata": "^1.0.0",
         "userscripter": "6.0.0",
         "webpack": "^4.46.0",
@@ -18286,9 +18286,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -33506,9 +33506,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ts-preferences": "^2.0.0",
     "ts-storage": "^5.0.1",
     "ts-type-guards": "^0.6.1",
-    "typescript": "4.5.5",
+    "typescript": "4.9.5",
     "userscript-metadata": "^1.0.0",
     "userscripter": "6.0.0",
     "webpack": "^4.46.0",


### PR DESCRIPTION
I did this:

    npm install --save-exact typescript@4.9

Installing TypeScript 5.0 caused npm to emit this warning:

    npm warn ERESOLVE overriding peer dependency
    npm warn While resolving: undefined@undefined
    npm warn Found: typescript@4.9.5
    npm warn node_modules/typescript
    npm warn   peer typescript@">=3.8 <5.0" from ts-jest@26.4.4
    npm warn   node_modules/ts-jest
    npm warn     ts-jest@"^26.4.4" from the root project
    npm warn   3 more (ts-loader, tsutils, the root project)
    npm warn
    npm warn Could not resolve dependency:
    npm warn peer typescript@">=3.8 <5.0" from ts-jest@26.4.4
    npm warn node_modules/ts-jest
    npm warn   ts-jest@"^26.4.4" from the root project